### PR TITLE
Fix mobile navigation button

### DIFF
--- a/docs/src/_components/mobile_menu.liquid
+++ b/docs/src/_components/mobile_menu.liquid
@@ -1,6 +1,6 @@
 <!-- Mobile Menu Component -->
 <div class="lg:hidden hidden" role="dialog" aria-modal="true" id="mobile-menu">
-  <div class="fixed inset-0 z-50"></div>
+  <div class="fixed inset-0 z-50" id="mobile-menu-backdrop"></div>
   <div class="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
     <div class="flex items-center justify-between">
       <a href="{{ '/' | relative_url }}" class="-m-1.5 p-1.5 flex items-center gap-2">

--- a/docs/src/_components/navigation.liquid
+++ b/docs/src/_components/navigation.liquid
@@ -11,7 +11,7 @@
   
   <!-- Mobile menu button -->
   <div class="flex lg:hidden">
-    <button type="button" class="mobile-menu-button -m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700">
+    <button type="button" id="mobile-menu-button" class="mobile-menu-button -m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700">
       <span class="sr-only">Open main menu</span>
       <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />


### PR DESCRIPTION
The mobile navigation button was non-functional due to missing element IDs that the JavaScript event handlers were trying to bind to. The mobile menu component existed but wasn't connected to the button.

Changes:
- Add missing `id="mobile-menu-button"` to navigation button element
- Add `id="mobile-menu-backdrop"` to backdrop div for click-to-close functionality

The mobile navigation now properly opens/closes, displays all navigation links, and closes via backdrop clicking and escape key.