### PR TITLE
fix(miprov2): improve optimization trace serialization for JSON output

### DIFF
--- a/lib/dspy/teleprompt/mipro_v2.rb
+++ b/lib/dspy/teleprompt/mipro_v2.rb
@@ -751,10 +751,25 @@ module DSPy
           best_score_value: best_score,
           metadata: metadata,
           evaluated_candidates: @evaluated_candidates,
-          optimization_trace: optimization_result[:optimization_state] || {},
+          optimization_trace: serialize_optimization_trace(optimization_result[:optimization_state]),
           bootstrap_statistics: bootstrap_result.statistics,
           proposal_statistics: proposal_result.analysis
         )
+      end
+
+      # Serialize optimization trace for better JSON output
+      sig { params(optimization_state: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
+      def serialize_optimization_trace(optimization_state)
+        return {} unless optimization_state
+        
+        serialized_trace = optimization_state.dup
+        
+        # Convert candidate objects to their hash representations
+        if serialized_trace[:candidates]
+          serialized_trace[:candidates] = serialized_trace[:candidates].map(&:to_h)
+        end
+        
+        serialized_trace
       end
 
       # Helper methods


### PR DESCRIPTION
Enhances optimization result serialization by properly converting candidate objects to readable JSON format instead of Ruby object representations.

**Problem:**
- Optimization trace contained unreadable object references like: `"#<DSPy::Teleprompt::MIPROv2::CandidateConfig:0x000000030a3d7900>"`
- Made it impossible to inspect candidate configurations in saved results
- Poor debugging experience when analyzing optimization history

**Solution:**
- Add `serialize_optimization_trace` method to handle candidate object serialization
- Convert CandidateConfig objects to hash representations using `.to_h`
- Extract serialization logic into reusable, well-typed method
- Preserve all optimization state while making it JSON-friendly

**Result:**
- Optimization traces now contain readable candidate data: ```json { "instruction": "Analyze the email with subject...", "few_shot_examples": 2, "metadata": {"type": "combined", "instruction_rank": 2}, "config_id": "ec6b1d3d42fe" } ```
- Better debugging and analysis capabilities for optimization results
- Cleaner separation of concerns in result building
