### PR TITLE
fix: resolve signature_class null issue in program storage and agents

### DIFF
--- a/spec/dspy/storage/storage_manager_spec.rb
+++ b/spec/dspy/storage/storage_manager_spec.rb
@@ -162,7 +162,7 @@ end
         mock_optimization_result,
         tags: ['mipro', 'test']
       )
-      
+
       high_score_result = double('HighScoreResult',
         optimized_program: different_program,
         best_score_value: 0.95,


### PR DESCRIPTION
  ## Problem
  Storage history was showing `signature_class` as null instead of proper class names like
  "UniversalFlow::ManageExtractionConversation", making it difficult to identify and track programs in storage systems.

  ## Root Cause
  - `ProgramStorage#update_history` was looking for `signature_class` in metadata instead of extracting it directly from
  program objects
  - CodeAct and ReAct agents were using dynamic class names that didn't preserve original signature information
  - During export/import, `serialize_program` was re-extracting state from already-serialized Hash objects, creating empty
  state
  - Mock program setup in tests wasn't properly responding to `respond_to?` checks

  ## Solution
  - Extract `signature_class` directly from `program.signature_class.name` in storage operations
  - Add signature name tracking to CodeAct and ReAct agents with `@original_signature_name` and accessor methods
  - Fix `serialize_program` to preserve existing state for already-serialized programs
  - Add comprehensive signature class validation with descriptive error messages
  - Enhance test coverage for signature class extraction scenarios across different program types