### PR TITLE
fix: resolve nilable T::Struct fields causing MIPROv2 optimization failures

### DIFF
--- a/spec/dspy/predict_nilable_integration_spec.rb
+++ b/spec/dspy/predict_nilable_integration_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+RSpec.describe 'DSPy::Predict with T.nilable fields integration' do
+  # This tests the exact scenario described in the plan where MIPROv2 optimization
+  # would fail due to nilable fields containing nil values during struct instantiation
+
+  class NilableFieldsSignature < DSPy::Signature
+    description "Test signature with nilable output fields"
+
+    input do
+      const :query, String
+    end
+
+    output do
+      const :answer, String
+      const :confidence, T.nilable(Float)
+      const :explanation, T.nilable(String)
+      const :metadata, T.nilable(T::Hash[String, T.untyped])
+    end
+  end
+
+  before do
+    DSPy.configure do |c|
+      c.lm = DSPy::LM.new('openai/gpt-4o-mini', api_key: ENV['OPENAI_API_KEY'] || 'stub-key')
+      # Preserve the logger configuration from spec_helper
+      c.logger = Dry.Logger(:dspy, formatter: :string) { |s| s.add_backend(stream: "log/test.log") }
+    end
+  end
+
+  let(:predict) { DSPy::Predict.new(NilableFieldsSignature) }
+
+  describe 'struct instantiation with nilable fields' do
+    it 'successfully creates prediction when nilable fields are nil', vcr: { cassette_name: 'predict_nilable_integration' } do
+      skip 'Requires OPENAI_API_KEY' unless ENV['OPENAI_API_KEY']
+      
+      # Mock the LLM to return parsed attributes with nil values for nilable fields
+      allow_any_instance_of(DSPy::LM).to receive(:chat).and_return(
+        {
+          answer: 'This is the answer',
+          confidence: nil,      # nilable field with nil value
+          explanation: nil,     # nilable field with nil value  
+          metadata: nil         # nilable field with nil value
+        }
+      )
+
+      # This should not throw PredictionInvalidError or struct instantiation errors
+      expect {
+        result = predict.call(query: "What is 2+2?")
+        
+        # Verify the result structure
+        expect(result.answer).to eq('This is the answer')
+        expect(result.confidence).to be_nil
+        expect(result.explanation).to be_nil
+        expect(result.metadata).to be_nil
+      }.not_to raise_error
+    end
+
+    it 'successfully creates prediction when nilable fields have values', vcr: { cassette_name: 'predict_nilable_with_values' } do
+      skip 'Requires OPENAI_API_KEY' unless ENV['OPENAI_API_KEY']
+      
+      # Mock the LLM to return parsed attributes with values for nilable fields
+      allow_any_instance_of(DSPy::LM).to receive(:chat).and_return(
+        {
+          answer: 'This is the answer',
+          confidence: 0.95,
+          explanation: 'Simple arithmetic',
+          metadata: { 'source' => 'calculator' }
+        }
+      )
+
+      expect {
+        result = predict.call(query: "What is 2+2?")
+        
+        # Verify the result structure
+        expect(result.answer).to eq('This is the answer')
+        expect(result.confidence).to eq(0.95)
+        expect(result.explanation).to eq('Simple arithmetic')
+        expect(result.metadata).to eq({ 'source' => 'calculator' })
+      }.not_to raise_error
+    end
+
+    it 'handles mixed nilable field scenarios', vcr: { cassette_name: 'predict_nilable_mixed' } do
+      skip 'Requires OPENAI_API_KEY' unless ENV['OPENAI_API_KEY']
+      
+      # Mock the LLM to return parsed attributes with some nilable fields nil and some with values
+      allow_any_instance_of(DSPy::LM).to receive(:chat).and_return(
+        {
+          answer: 'This is the answer',
+          confidence: 0.8,          # has value
+          explanation: nil,         # nil
+          metadata: { 'key' => 'val' }  # has value
+        }
+      )
+
+      expect {
+        result = predict.call(query: "What is 2+2?")
+        
+        # Verify the result structure
+        expect(result.answer).to eq('This is the answer')
+        expect(result.confidence).to eq(0.8)
+        expect(result.explanation).to be_nil
+        expect(result.metadata).to eq({ 'key' => 'val' })
+      }.not_to raise_error
+    end
+  end
+
+  describe 'optimization scenario simulation' do
+    # This simulates what happens during MIPROv2 optimization when it tries to
+    # create predictions from LLM outputs that contain nil for nilable fields
+    
+    it 'handles the exact scenario that would cause optimization to fail' do
+      # Simulate the attributes that would come from LLM output processing
+      # This is exactly what would be passed to create_prediction_result during optimization
+      input_values = { query: "What is the meaning of life?" }
+      output_attributes = {
+        answer: "42",
+        confidence: nil,    # This used to cause PredictionInvalidError
+        explanation: nil,   # This used to cause PredictionInvalidError
+        metadata: nil       # This used to cause PredictionInvalidError
+      }
+      
+      # This should not raise any errors
+      expect {
+        # Directly test the internal method that was failing
+        prediction_result = predict.send(:create_prediction_result, input_values, output_attributes)
+        
+        expect(prediction_result.query).to eq("What is the meaning of life?")
+        expect(prediction_result.answer).to eq("42")
+        expect(prediction_result.confidence).to be_nil
+        expect(prediction_result.explanation).to be_nil
+        expect(prediction_result.metadata).to be_nil
+      }.not_to raise_error(DSPy::PredictionInvalidError)
+    end
+  end
+end

--- a/spec/dspy/prediction_nilable_spec.rb
+++ b/spec/dspy/prediction_nilable_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'DSPy::Prediction T.nilable handling' do
+  describe 'basic T.nilable types' do
+    class BasicNilableSignature < DSPy::Signature
+      output do
+        const :name, T.nilable(String)
+        const :count, T.nilable(Integer)
+        const :active, T.nilable(T::Boolean)
+      end
+    end
+
+    it 'handles nil values correctly' do
+      prediction = DSPy::Prediction.new(
+        BasicNilableSignature.output_schema,
+        name: nil,
+        count: nil,
+        active: nil
+      )
+
+      expect(prediction.name).to be_nil
+      expect(prediction.count).to be_nil
+      expect(prediction.active).to be_nil
+    end
+
+    it 'handles non-nil values correctly' do
+      prediction = DSPy::Prediction.new(
+        BasicNilableSignature.output_schema,
+        name: 'test',
+        count: 42,
+        active: true
+      )
+
+      expect(prediction.name).to eq('test')
+      expect(prediction.count).to eq(42)
+      expect(prediction.active).to be(true)
+    end
+  end
+
+  describe 'T.nilable with arrays' do
+    class NilableArraySignature < DSPy::Signature
+      output do
+        const :items, T.nilable(T::Array[String])
+        const :numbers, T.nilable(T::Array[Integer])
+      end
+    end
+
+    it 'handles nil arrays' do
+      prediction = DSPy::Prediction.new(
+        NilableArraySignature.output_schema,
+        items: nil,
+        numbers: nil
+      )
+
+      expect(prediction.items).to be_nil
+      expect(prediction.numbers).to be_nil
+    end
+
+    it 'handles empty arrays' do
+      prediction = DSPy::Prediction.new(
+        NilableArraySignature.output_schema,
+        items: [],
+        numbers: []
+      )
+
+      expect(prediction.items).to eq([])
+      expect(prediction.numbers).to eq([])
+    end
+
+    it 'handles populated arrays' do
+      prediction = DSPy::Prediction.new(
+        NilableArraySignature.output_schema,
+        items: ['a', 'b', 'c'],
+        numbers: [1, 2, 3]
+      )
+
+      expect(prediction.items).to eq(['a', 'b', 'c'])
+      expect(prediction.numbers).to eq([1, 2, 3])
+    end
+  end
+
+  describe 'T.nilable with struct types' do
+    class PredictionTestStruct < T::Struct
+      const :value, String
+    end
+
+    class NilableStructSignature < DSPy::Signature
+      output do
+        const :data, T.nilable(PredictionTestStruct)
+      end
+    end
+
+    it 'handles nil struct' do
+      prediction = DSPy::Prediction.new(
+        NilableStructSignature.output_schema,
+        data: nil
+      )
+
+      expect(prediction.data).to be_nil
+    end
+
+    it 'handles actual struct conversion' do
+      prediction = DSPy::Prediction.new(
+        NilableStructSignature.output_schema,
+        data: { value: 'test' }
+      )
+
+      expect(prediction.data).to be_a(PredictionTestStruct)
+      expect(prediction.data.value).to eq('test')
+    end
+  end
+
+  describe 'T.nilable with union types in arrays' do
+    module NilableUnionTypes
+      class TypeA < T::Struct
+        const :type, String, default: 'a'
+        const :value_a, String
+      end
+
+      class TypeB < T::Struct
+        const :type, String, default: 'b'
+        const :value_b, Integer
+      end
+    end
+
+    class NilableUnionArraySignature < DSPy::Signature
+      output do
+        const :items, T.nilable(T::Array[T.any(
+          NilableUnionTypes::TypeA,
+          NilableUnionTypes::TypeB
+        )])
+      end
+    end
+
+    it 'handles nil array with union types' do
+      prediction = DSPy::Prediction.new(
+        NilableUnionArraySignature.output_schema,
+        items: nil
+      )
+
+      expect(prediction.items).to be_nil
+    end
+
+    it 'handles empty array with union types' do
+      prediction = DSPy::Prediction.new(
+        NilableUnionArraySignature.output_schema,
+        items: []
+      )
+
+      expect(prediction.items).to eq([])
+    end
+
+    it 'handles populated array with union type conversion' do
+      prediction = DSPy::Prediction.new(
+        NilableUnionArraySignature.output_schema,
+        items: [
+          { type: 'a', value_a: 'test' },
+          { type: 'b', value_b: 42 }
+        ]
+      )
+
+      expect(prediction.items).to be_an(Array)
+      expect(prediction.items.length).to eq(2)
+      expect(prediction.items[0]).to be_a(NilableUnionTypes::TypeA)
+      expect(prediction.items[0].value_a).to eq('test')
+      expect(prediction.items[1]).to be_a(NilableUnionTypes::TypeB)
+      expect(prediction.items[1].value_b).to eq(42)
+    end
+  end
+
+  describe 'T.nilable with enums' do
+    class NilableTestPriority < T::Enum
+      enums do
+        Low = new('low')
+        Medium = new('medium')
+        High = new('high')
+      end
+    end
+
+    class NilableEnumTestSignature < DSPy::Signature
+      output do
+        const :priority, T.nilable(NilableTestPriority)
+        const :regular_priority, NilableTestPriority
+      end
+    end
+
+    it 'handles nil enum values' do
+      prediction = DSPy::Prediction.new(
+        NilableEnumTestSignature.output_schema,
+        priority: nil,
+        regular_priority: 'medium'
+      )
+
+      expect(prediction.priority).to be_nil
+      expect(prediction.regular_priority).to eq(NilableTestPriority::Medium)
+    end
+
+    it 'handles string to enum conversion for nilable enums' do
+      prediction = DSPy::Prediction.new(
+        NilableEnumTestSignature.output_schema,
+        priority: 'high',
+        regular_priority: 'low'
+      )
+
+      expect(prediction.priority).to eq(NilableTestPriority::High)
+      expect(prediction.regular_priority).to eq(NilableTestPriority::Low)
+    end
+
+    it 'handles missing nilable enum fields' do
+      prediction = DSPy::Prediction.new(
+        NilableEnumTestSignature.output_schema,
+        regular_priority: 'medium'
+      )
+
+      expect(prediction.priority).to be_nil
+      expect(prediction.regular_priority).to eq(NilableTestPriority::Medium)
+    end
+  end
+
+  describe 'complex nested T.nilable scenarios' do
+    class ComplexNestedStruct < T::Struct
+      const :nested_value, T.nilable(String)
+      const :nested_array, T.nilable(T::Array[Integer])
+    end
+
+    class ComplexNilableSignature < DSPy::Signature
+      output do
+        const :wrapper, T.nilable(ComplexNestedStruct)
+        const :array_of_nilable_structs, T::Array[T.nilable(ComplexNestedStruct)]
+      end
+    end
+
+    it 'handles deeply nested nilable types' do
+      prediction = DSPy::Prediction.new(
+        ComplexNilableSignature.output_schema,
+        wrapper: nil,
+        array_of_nilable_structs: [nil, { nested_value: 'test', nested_array: nil }]
+      )
+
+      expect(prediction.wrapper).to be_nil
+      expect(prediction.array_of_nilable_structs).to be_an(Array)
+      expect(prediction.array_of_nilable_structs[0]).to be_nil
+      expect(prediction.array_of_nilable_structs[1]).to be_a(ComplexNestedStruct)
+      expect(prediction.array_of_nilable_structs[1].nested_value).to eq('test')
+      expect(prediction.array_of_nilable_structs[1].nested_array).to be_nil
+    end
+  end
+end

--- a/spec/dspy/signature_nilable_schema_spec.rb
+++ b/spec/dspy/signature_nilable_schema_spec.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'DSPy::Signature T.nilable JSON Schema Generation' do
+  describe 'basic T.nilable types' do
+    class BasicNilableSchemaSignature < DSPy::Signature
+      output do
+        const :name, T.nilable(String)
+        const :count, T.nilable(Integer)  
+        const :score, T.nilable(Float)
+        const :active, T.nilable(T::Boolean)
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(String)' do
+      schema = BasicNilableSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:name]).to eq({
+        type: ['string', 'null']
+      })
+    end
+
+    it 'generates correct JSON schema for T.nilable(Integer)' do
+      schema = BasicNilableSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:count]).to eq({
+        type: ['integer', 'null']
+      })
+    end
+
+    it 'generates correct JSON schema for T.nilable(Float)' do
+      schema = BasicNilableSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:score]).to eq({
+        type: ['number', 'null']
+      })
+    end
+
+    it 'generates correct JSON schema for T.nilable(T::Boolean)' do
+      schema = BasicNilableSchemaSignature.output_json_schema
+      
+      # T.nilable(T::Boolean) should generate simple nilable boolean schema
+      expect(schema[:properties][:active]).to eq({
+        type: ['boolean', 'null']
+      })
+    end
+  end
+
+  describe 'T.nilable with enums' do
+    class Status < T::Enum
+      enums do
+        Active = new('active')
+        Inactive = new('inactive')
+        Pending = new('pending')
+      end
+    end
+
+    class NilableEnumSignature < DSPy::Signature
+      output do
+        const :status, T.nilable(Status)
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(Enum)' do
+      schema = NilableEnumSignature.output_json_schema
+      
+      expect(schema[:properties][:status]).to eq({
+        type: ['string', 'null'],
+        enum: ['active', 'inactive', 'pending']
+      })
+    end
+  end
+
+  describe 'T.nilable with arrays' do
+    class NilableArraySchemaSignature < DSPy::Signature
+      output do
+        const :items, T.nilable(T::Array[String])
+        const :numbers, T.nilable(T::Array[Integer])
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(Array[String])' do
+      schema = NilableArraySchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:items]).to eq({
+        type: ['array', 'null'],
+        items: { type: 'string' }
+      })
+    end
+
+    it 'generates correct JSON schema for T.nilable(Array[Integer])' do
+      schema = NilableArraySchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:numbers]).to eq({
+        type: ['array', 'null'],
+        items: { type: 'integer' }
+      })
+    end
+  end
+
+  describe 'T.nilable with custom structs' do
+    class TestStruct < T::Struct
+      const :value, String
+      const :count, Integer
+    end
+
+    class NilableStructSchemaSignature < DSPy::Signature
+      output do
+        const :data, T.nilable(TestStruct)
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(CustomStruct)' do
+      schema = NilableStructSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:data]).to eq({
+        type: ['object', 'null'],
+        properties: {
+          _type: {
+            type: 'string',
+            const: 'TestStruct'
+          },
+          value: { type: 'string' },
+          count: { type: 'integer' }
+        },
+        required: ['_type', 'value', 'count'],
+        description: "#{TestStruct.name} struct"
+      })
+    end
+  end
+
+  describe 'T.nilable with hash types' do
+    class NilableHashSchemaSignature < DSPy::Signature
+      output do
+        const :metadata, T.nilable(T::Hash[String, Integer])
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(Hash[String, Integer])' do
+      schema = NilableHashSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:metadata]).to eq({
+        type: ['object', 'null'],
+        propertyNames: { type: 'string' },
+        additionalProperties: { type: 'integer' },
+        description: 'A mapping where keys are strings and values are integers'
+      })
+    end
+  end
+
+  describe 'complex T.nilable union types' do
+    class UnionTypeA < T::Struct
+      const :type, String, default: 'a'
+      const :value_a, String
+    end
+
+    class UnionTypeB < T::Struct
+      const :type, String, default: 'b'
+      const :value_b, Integer
+    end
+
+    class NilableUnionSchemaSignature < DSPy::Signature
+      output do
+        const :choice, T.nilable(T.any(UnionTypeA, UnionTypeB))
+      end
+    end
+
+    it 'generates correct JSON schema for T.nilable(T.any(...))' do
+      schema = NilableUnionSchemaSignature.output_json_schema
+      
+      expect(schema[:properties][:choice]).to include({
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              _type: { type: 'string', const: 'UnionTypeA' },
+              type: { type: 'string' },
+              value_a: { type: 'string' }
+            },
+            required: ['_type', 'type', 'value_a'],
+            description: "#{UnionTypeA.name} struct"
+          },
+          {
+            type: 'object', 
+            properties: {
+              _type: { type: 'string', const: 'UnionTypeB' },
+              type: { type: 'string' },
+              value_b: { type: 'integer' }
+            },
+            required: ['_type', 'type', 'value_b'],
+            description: "#{UnionTypeB.name} struct"
+          },
+          { type: 'null' }
+        ],
+        description: 'Union of multiple types'
+      })
+    end
+  end
+
+  describe 'nested T.nilable scenarios' do
+    class NestedStruct < T::Struct
+      const :name, String
+      const :optional_value, T.nilable(String)
+      const :optional_list, T.nilable(T::Array[Integer])
+    end
+
+    class NestedNilableSignature < DSPy::Signature
+      output do
+        const :wrapper, T.nilable(NestedStruct)
+        const :array_of_nilable, T::Array[T.nilable(String)]
+      end
+    end
+
+    it 'generates correct schema for nested struct with nilable fields' do
+      schema = NestedNilableSignature.output_json_schema
+      
+      # Check the nilable wrapper struct
+      expect(schema[:properties][:wrapper]).to eq({
+        type: ['object', 'null'],
+        properties: {
+          _type: { type: 'string', const: 'NestedStruct' },
+          name: { type: 'string' },
+          optional_value: { type: ['string', 'null'] },
+          optional_list: {
+            type: ['array', 'null'],
+            items: { type: 'integer' }
+          }
+        },
+        required: ['_type', 'name'],
+        description: "#{NestedStruct.name} struct"
+      })
+    end
+
+    it 'generates correct schema for array of nilable items' do
+      schema = NestedNilableSignature.output_json_schema
+      
+      expect(schema[:properties][:array_of_nilable]).to eq({
+        type: 'array',
+        items: { type: ['string', 'null'] }
+      })
+    end
+  end
+
+  describe 'required field handling with nilable types' do
+    class RequiredNilableSignature < DSPy::Signature
+      output do
+        const :required_nilable, T.nilable(String)
+        const :optional_nilable, T.nilable(String), default: nil
+        const :required_regular, String
+      end
+    end
+
+    it 'correctly marks nilable fields as required unless they have defaults' do
+      schema = RequiredNilableSignature.output_json_schema
+      
+      expect(schema[:required]).to include('required_nilable')
+      expect(schema[:required]).not_to include('optional_nilable')
+      expect(schema[:required]).to include('required_regular')
+    end
+  end
+
+  describe 'edge cases and error handling' do
+    # Test case for empty union (shouldn't happen in practice but test robustness)
+    it 'handles malformed types gracefully' do
+      # This is more of a robustness test - the actual implementation
+      # should handle edge cases without crashing
+      
+      class EdgeCaseSignature < DSPy::Signature
+        output do
+          const :safe_field, String
+        end
+      end
+
+      expect {
+        EdgeCaseSignature.output_json_schema
+      }.not_to raise_error
+    end
+
+    # Test for deeply nested nilable structures
+    class DeeplyNestedStruct < T::Struct
+      const :level1, T.nilable(String)
+      const :level2, T.nilable(T::Array[T.nilable(Integer)])
+    end
+
+    class DeepNilableSignature < DSPy::Signature
+      output do
+        const :deep, T.nilable(T::Array[T.nilable(DeeplyNestedStruct)])
+      end
+    end
+
+    it 'handles deeply nested nilable types' do
+      schema = DeepNilableSignature.output_json_schema
+      
+      # Should generate proper schema without errors
+      expect(schema[:properties][:deep]).to include({
+        type: ['array', 'null']
+      })
+      
+      # The items should be objects that can also be null
+      items_schema = schema[:properties][:deep][:items]
+      expect(items_schema[:type]).to include('object')
+      expect(items_schema[:type]).to include('null')
+      expect(items_schema[:properties][:level1][:type]).to eq(['string', 'null'])
+      expect(items_schema[:properties][:level2][:type]).to eq(['array', 'null'])
+      expect(items_schema[:properties][:level2][:items][:type]).to eq(['integer', 'null'])
+    end
+
+    # Test multiple nilable fields in one signature
+    class MultiNilableSignature < DSPy::Signature
+      output do
+        const :string_field, T.nilable(String)
+        const :int_field, T.nilable(Integer) 
+        const :array_field, T.nilable(T::Array[String])
+        const :regular_field, String  # Non-nilable for comparison
+      end
+    end
+
+    it 'generates correct schema for signature with multiple nilable fields' do
+      schema = MultiNilableSignature.output_json_schema
+      
+      # Nilable fields should have null in their type array
+      expect(schema[:properties][:string_field][:type]).to eq(['string', 'null'])
+      expect(schema[:properties][:int_field][:type]).to eq(['integer', 'null'])
+      expect(schema[:properties][:array_field][:type]).to eq(['array', 'null'])
+      
+      # Regular field should not have null
+      expect(schema[:properties][:regular_field][:type]).to eq('string')
+      
+      # All required fields should be present (nilable doesn't affect required unless there's a default)
+      expect(schema[:required]).to include('string_field', 'int_field', 'array_field', 'regular_field')
+    end
+  end
+end

--- a/spec/dspy/signature_spec.rb
+++ b/spec/dspy/signature_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DSPy::Signature do
         type: "object",
         properties: {
           sentence: { type: "string" },
-          context: { type: "string" }
+          context: { type: ["string", "null"] }  # T.nilable(String) correctly generates nilable type
         },
         required: ["sentence"]  # context is not required due to default
       })
@@ -86,7 +86,7 @@ RSpec.describe DSPy::Signature do
         properties: {
           sentiment: { type: "string" },  # For now, just string type
           confidence: { type: "number" },
-          explanation: { type: "string" }
+          explanation: { type: ["string", "null"] }  # T.nilable(String) correctly generates nilable type
         },
         required: ["sentiment", "confidence"]  # explanation is not required due to default
       })

--- a/spec/dspy/storage/program_storage_spec.rb
+++ b/spec/dspy/storage/program_storage_spec.rb
@@ -3,6 +3,29 @@ require 'tempfile'
 require 'tmpdir'
 require 'dspy/storage/program_storage'
 
+# Mock program class for serialization tests
+class MockProgram
+  extend T::Sig
+
+  sig { returns(T.class_of(DSPy::Signature)) }
+  def signature_class
+    ManageExtractionConversation
+  end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def to_h
+    {
+      class_name: self.class.name,
+      signature_class_name: signature_class.name
+    }
+  end
+
+  sig { params(data: T::Hash[Symbol, T.untyped]).returns(MockProgram) }
+  def self.from_h(data)
+    new
+  end
+end
+
 # Test signature class for deserialization tests
 class ManageExtractionConversation < DSPy::Signature
   description "Manage conversation flow for entity extraction tasks"


### PR DESCRIPTION

Problem: 
MIPROv2 optimization was failing during struct instantiation when nilable fields contained nil values, causing PredictionInvalidError and preventing optimization from completing successfully.

Root Cause: 
Three interconnected issues in the type handling system:
1. StructBuilder was not properly extracting type_object for nilable types, leading to incorrect struct property definitions
2. JSON schema generation was incomplete for T.nilable types, especially T::Private::Types::SimplePairUnion (the actual implementation of T.nilable)
3. Predict module lacked preprocessing for nilable attributes before struct instantiation, causing ArgumentError when nil values were passed to required struct fields

Solution:
- Enhanced StructBuilder to prioritize type_object over type for nilable fields and properly handle fully_optional flags with nil defaults
- Expanded JSON schema generation to support SimplePairUnion types and generate proper ["type", "null"] schemas for all nilable variations
- Added nilable attribute preprocessing in Predict module to validate and handle nil values before struct creation
- Improved enum type detection and extraction for complex nilable enum types
- Added comprehensive test coverage for nilable types in signatures, predictions, and integration scenarios
