### PR TITLE
feat: add detailed evaluation result tracking to MIPROv2 optimization

### DIFF
--- a/lib/dspy/evaluate.rb
+++ b/lib/dspy/evaluate.rb
@@ -49,7 +49,7 @@ module DSPy
       def to_h
         {
           example: @example,
-          prediction: @prediction,
+          prediction: @prediction.respond_to?(:to_h) ? @prediction.to_h : @prediction,
           trace: @trace,
           metrics: @metrics,
           passed: @passed


### PR DESCRIPTION
Problem: MIPROv2 optimizer was only preserving final scores from optimization, losing valuable detailed evaluation metrics and individual example results that could be useful for analysis and debugging.

Root Cause: The optimizer discarded full evaluation context after extracting pass rates, making it impossible to analyze why certain candidates performed better and what specific examples contributed to the scores.

Solution: Enhanced MIPROv2 to preserve complete evaluation results by:
- Adding best_evaluation_result attribute to MIPROv2Result class
- Modifying evaluate_candidate to return full evaluation context
- Improving prediction serialization with proper to_h handling
- Adding comprehensive tests for evaluation result preservation