### PR TITLE
feat: add comprehensive type alias support to DSPy framework

### DIFF
--- a/spec/dspy/lm/strategies/enhanced_prompting_strategy_type_alias_spec.rb
+++ b/spec/dspy/lm/strategies/enhanced_prompting_strategy_type_alias_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+
+RSpec.describe DSPy::LM::Strategies::EnhancedPromptingStrategy do
+  # Create a minimal test adapter
+  class TypeAliasTestAdapter < DSPy::LM::Adapter
+    def call_api(messages, **params)
+      DSPy::LM::Response.new(
+        content: '{"answer": "test", "confidence": 0.9}',
+        role: 'assistant',
+        stop_reason: 'end_turn'
+      )
+    end
+  end
+
+  let(:adapter) { TypeAliasTestAdapter.new(model: "test-model", api_key: "test-key") }
+  let(:signature_class) { TypeAliasTestSignature }
+  let(:strategy) { described_class.new(adapter, signature_class) }
+
+  # Define type aliases for testing
+  TestResponse = T.type_alias do
+    {
+      "answer" => String,
+      "confidence" => Float,
+      "sources" => T::Array[T::Hash[String, T.untyped]]
+    }
+  end
+
+  class TypeAliasTestSignature < DSPy::Signature
+    description "Test signature for enhanced prompting with type aliases"
+    
+    input do
+      const :question, String
+    end
+    
+    output do
+      const :response, T.nilable(TestResponse)
+      const :simple_field, String
+    end
+  end
+
+  describe "#generate_example_value" do
+    it "generates proper examples for nested objects" do
+      field_schema = {
+        type: "object",
+        properties: {
+          "answer" => { type: "string" },
+          "confidence" => { type: "number" },
+          "sources" => {
+            type: "array",
+            items: {
+              type: "object",
+              propertyNames: { type: "string" },
+              additionalProperties: { type: "string" }
+            }
+          }
+        }
+      }
+
+      result = strategy.send(:generate_example_value, field_schema)
+      
+      expect(result).to be_a(Hash)
+      expect(result["answer"]).to eq("example string")
+      expect(result["confidence"]).to eq(3.14)
+      expect(result["sources"]).to be_an(Array)
+      expect(result["sources"].first).to be_a(Hash)
+    end
+
+    it "generates proper examples for union types with objects" do
+      field_schema = {
+        type: ["object", "null"],
+        properties: {
+          "data" => { type: "string" },
+          "count" => { type: "integer" }
+        }
+      }
+
+      result = strategy.send(:generate_example_value, field_schema)
+      
+      expect(result).to be_a(Hash)
+      expect(result["data"]).to eq("example string")
+      expect(result["count"]).to eq(42)
+    end
+
+    it "generates proper examples for nested arrays" do
+      field_schema = {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            "name" => { type: "string" },
+            "value" => { type: "number" }
+          }
+        }
+      }
+
+      result = strategy.send(:generate_example_value, field_schema)
+      
+      expect(result).to be_an(Array)
+      expect(result.first).to be_a(Hash)
+      expect(result.first["name"]).to eq("example string")
+      expect(result.first["value"]).to eq(3.14)
+    end
+  end
+
+  describe "#generate_example_from_schema" do
+    it "generates complete examples for type alias schemas" do
+      schema = TypeAliasTestSignature.output_json_schema
+      
+      result = strategy.send(:generate_example_from_schema, schema)
+      
+      expect(result).to have_key("response")
+      expect(result).to have_key("simple_field")
+      
+      # Check the type alias field structure
+      response_example = result["response"]
+      expect(response_example).to be_a(Hash)
+      expect(response_example).to have_key("answer")
+      expect(response_example).to have_key("confidence")
+      expect(response_example).to have_key("sources")
+      
+      expect(response_example["answer"]).to eq("example string")
+      expect(response_example["confidence"]).to eq(3.14)
+      expect(response_example["sources"]).to be_an(Array)
+    end
+  end
+
+  describe "integration with enhanced prompting" do
+    it "creates proper JSON examples in prompts for type aliases" do
+      # Create a mock signature with type alias
+      allow(TypeAliasTestSignature).to receive(:output_json_schema).and_return(
+        TypeAliasTestSignature.output_json_schema
+      )
+
+      # Test that enhanced prompting includes proper structured examples
+      schema = TypeAliasTestSignature.output_json_schema
+      enhanced_prompt = strategy.send(:enhance_prompt_with_json_instructions, "Test prompt", schema)
+      
+      expect(enhanced_prompt).to include("answer")
+      expect(enhanced_prompt).to include("confidence")
+      expect(enhanced_prompt).to include("sources")
+      expect(enhanced_prompt).to include("example string")
+      expect(enhanced_prompt).to include("3.14")
+      
+      # Verify it's valid JSON structure in the prompt
+      json_match = enhanced_prompt.match(/```json\n(.*?)\n```/m)
+      expect(json_match).not_to be_nil
+      
+      parsed_example = JSON.parse(json_match[1])
+      expect(parsed_example["response"]).to be_a(Hash)
+      expect(parsed_example["response"]["answer"]).to be_a(String)
+      expect(parsed_example["response"]["confidence"]).to be_a(Numeric)
+    end
+  end
+end

--- a/spec/dspy/type_alias_spec.rb
+++ b/spec/dspy/type_alias_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+require 'dspy/signature'
+
+# Define test type aliases
+SimpleResponse = T.type_alias { T::Hash[String, String] }
+
+ComplexResponse = T.type_alias do
+  {
+    "answer" => String,
+    "confidence" => Float,
+    "metadata" => T::Hash[String, T.untyped]
+  }
+end
+
+NestedResponse = T.type_alias do
+  {
+    "result" => String,
+    "details" => T::Array[T::Hash[String, String]],
+    "summary" => {
+      "total" => Integer,
+      "success" => T::Boolean
+    }
+  }
+end
+
+# Define test signatures using type aliases
+class SimpleTypeAliasSignature < DSPy::Signature
+  description "Test signature with simple type alias"
+  
+  input do
+    const :query, String
+  end
+  
+  output do
+    const :response, SimpleResponse
+  end
+end
+
+class ComplexTypeAliasSignature < DSPy::Signature
+  description "Test signature with complex type alias"
+  
+  input do
+    const :question, String
+  end
+  
+  output do
+    const :result, T.nilable(ComplexResponse)
+  end
+end
+
+class NestedTypeAliasSignature < DSPy::Signature
+  description "Test signature with nested type alias"
+  
+  input do
+    const :data, String
+  end
+  
+  output do
+    const :analysis, NestedResponse
+  end
+end
+
+RSpec.describe "Type Alias Support" do
+  describe "simple type alias schema generation" do
+    it "generates correct schema for simple hash type alias" do
+      schema = SimpleTypeAliasSignature.output_json_schema
+      
+      expect(schema[:properties][:response]).to eq({
+        type: "object",
+        propertyNames: { type: "string" },
+        additionalProperties: { type: "string" },
+        description: "A mapping where keys are strings and values are strings"
+      })
+    end
+  end
+
+  describe "complex type alias schema generation" do
+    it "generates correct schema for structured type alias" do
+      schema = ComplexTypeAliasSignature.output_json_schema
+      
+      expect(schema[:properties][:result]).to eq({
+        type: ["object", "null"],
+        properties: {
+          "answer" => { type: "string" },
+          "confidence" => { type: "number" },
+          "metadata" => {
+            type: "object",
+            propertyNames: { type: "string" },
+            additionalProperties: { type: "string" },
+            description: "A mapping where keys are strings and values are strings"
+          }
+        },
+        required: ["answer", "confidence", "metadata"],
+        additionalProperties: false
+      })
+    end
+  end
+
+  describe "nested type alias schema generation" do
+    it "generates correct schema for deeply nested structures" do
+      schema = NestedTypeAliasSignature.output_json_schema
+      
+      expect(schema[:properties][:analysis]).to eq({
+        type: "object",
+        properties: {
+          "result" => { type: "string" },
+          "details" => {
+            type: "array",
+            items: {
+              type: "object",
+              propertyNames: { type: "string" },
+              additionalProperties: { type: "string" },
+              description: "A mapping where keys are strings and values are strings"
+            }
+          },
+          "summary" => {
+            type: "object",
+            properties: {
+              "total" => { type: "integer" },
+              "success" => { type: "boolean" }
+            },
+            required: ["total", "success"],
+            additionalProperties: false
+          }
+        },
+        required: ["result", "details", "summary"],
+        additionalProperties: false
+      })
+    end
+  end
+
+  describe "type alias resolution" do
+    it "resolves type aliases to their underlying types" do
+      # Test that the framework recognizes type aliases
+      expect(ComplexResponse).to be_a(T::Private::Types::TypeAlias)
+      expect(ComplexResponse.aliased_type).to be_a(T::Types::FixedHash)
+      expect(ComplexResponse.aliased_type.types.keys).to include("answer", "confidence", "metadata")
+    end
+  end
+end


### PR DESCRIPTION
Problem:
Type aliases (T.type_alias) were not supported by the framework's schema generation system, causing LLMs to receive generic "example value" placeholders instead of proper structured examples for complex response types.

Root Cause:
The type_to_json_schema method in signature.rb only handled direct types and did not recognize T::Private::Types::TypeAlias or resolve them to their underlying T::Types::FixedHash structures. Additionally, the enhanced prompting strategy's example generation fell back to generic strings for complex object schemas.

Solution:
- Added type alias detection and resolution in signature.rb:191-194
- Added T::Types::FixedHash handling in signature.rb:265-280 for proper object schema generation with specific properties and required fields
- Enhanced example generation in enhanced_prompting_strategy.rb:122-166 with recursive generate_example_value method that properly handles nested objects, arrays, and union types
- Added comprehensive test coverage with 9 new tests covering schema generation   and example generation for simple, complex, and nested type aliases

This enables developers to use type aliases for structured responses while ensuring LLMs receive proper JSON schemas with realistic examples.