### PR TITLE
Enable structured outputs for Gemini Flash models

### DIFF
--- a/lib/dspy/lm/adapters/gemini/schema_converter.rb
+++ b/lib/dspy/lm/adapters/gemini/schema_converter.rb
@@ -11,24 +11,30 @@ module DSPy
           extend T::Sig
 
           # Models that support structured outputs (JSON + Schema)
-          # Based on official Google documentation and gemini-ai gem table
+          # Based on official Google documentation (Sept 2025)
           STRUCTURED_OUTPUT_MODELS = T.let([
-            "gemini-1.5-pro",              # ✅ Full schema support (legacy)
-            "gemini-1.5-pro-preview-0514", # ✅ Full schema support (legacy)
-            "gemini-1.5-pro-preview-0409", # ✅ Full schema support (legacy)
-            "gemini-2.5-flash",            # ✅ Full schema support (2025 current)
-            "gemini-2.5-flash-lite"        # ✅ Full schema support (2025 current)
+            # Gemini 1.5 series
+            "gemini-1.5-pro",
+            "gemini-1.5-pro-preview-0514",
+            "gemini-1.5-pro-preview-0409", 
+            "gemini-1.5-flash",             # ✅ Now supports structured outputs
+            "gemini-1.5-flash-preview-0514",
+            "gemini-1.5-flash-8b",
+            # Gemini 2.0 series
+            "gemini-2.0-flash",
+            "gemini-2.0-flash-001",
+            # Gemini 2.5 series
+            "gemini-2.5-pro",
+            "gemini-2.5-flash", 
+            "gemini-2.5-flash-lite"
           ].freeze, T::Array[String])
 
-          # Models that support JSON mode but NOT schema
-          JSON_ONLY_MODELS = T.let([
-            "gemini-pro",                   # 🟡 JSON only, no schema
-            "gemini-1.5-flash",             # 🟡 JSON only, no schema (legacy)
-            "gemini-1.5-flash-preview-0514", # 🟡 JSON only, no schema (legacy)
-            "gemini-1.0-pro-002",           # 🟡 JSON only, no schema
-            "gemini-1.0-pro",               # 🟡 JSON only, no schema
-            "gemini-2.0-flash-001",         # 🟡 JSON only, no schema (2025)
-            "gemini-2.0-flash-lite-001"     # 🟡 JSON only, no schema (2025)
+          # Models that do not support structured outputs (legacy only)
+          UNSUPPORTED_MODELS = T.let([
+            # Legacy Gemini 1.0 series only
+            "gemini-pro",                   
+            "gemini-1.0-pro-002",
+            "gemini-1.0-pro"
           ].freeze, T::Array[String])
 
           sig { params(signature_class: T.class_of(DSPy::Signature)).returns(T::Hash[Symbol, T.untyped]) }

--- a/spec/dspy/lm/adapters/gemini/schema_converter_spec.rb
+++ b/spec/dspy/lm/adapters/gemini/schema_converter_spec.rb
@@ -118,16 +118,32 @@ RSpec.describe DSPy::LM::Adapters::Gemini::SchemaConverter do
       expect(described_class.supports_structured_outputs?("gemini-1.5-pro")).to eq(true)
     end
     
-    it 'returns false for JSON-only models (no schema support)' do
-      # Based on official gemini-ai gem documentation: gemini-1.5-flash is JSON-only, not schema
-      expect(described_class.supports_structured_outputs?("gemini/gemini-1.5-flash")).to eq(false)
-      expect(described_class.supports_structured_outputs?("gemini-1.5-flash")).to eq(false)
+    it 'returns true for Gemini Flash models (now supported)' do
+      # Flash models now support structured outputs as of Sept 2025
+      expect(described_class.supports_structured_outputs?("gemini/gemini-1.5-flash")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini-1.5-flash")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini/gemini-1.5-flash-8b")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini-1.5-flash-8b")).to eq(true)
     end
     
-    it 'returns false for unsupported models' do
+    it 'returns true for Gemini 2.0 Flash models' do
+      expect(described_class.supports_structured_outputs?("gemini/gemini-2.0-flash")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini-2.0-flash")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini/gemini-2.0-flash-001")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini-2.0-flash-001")).to eq(true)
+    end
+    
+    it 'returns true for Gemini 2.5 Pro models' do
+      expect(described_class.supports_structured_outputs?("gemini/gemini-2.5-pro")).to eq(true)
+      expect(described_class.supports_structured_outputs?("gemini-2.5-pro")).to eq(true)
+    end
+    
+    it 'returns false for unsupported legacy models' do
       expect(described_class.supports_structured_outputs?("gemini/gemini-1.0-pro")).to eq(false)
       expect(described_class.supports_structured_outputs?("gemini-pro")).to eq(false)
       expect(described_class.supports_structured_outputs?("gemini-1.0-pro")).to eq(false)
+      expect(described_class.supports_structured_outputs?("gemini/gemini-1.0-pro-002")).to eq(false)
+      expect(described_class.supports_structured_outputs?("gemini-1.0-pro-002")).to eq(false)
     end
     
   end

--- a/spec/integration/gemini_structured_outputs_spec.rb
+++ b/spec/integration/gemini_structured_outputs_spec.rb
@@ -114,9 +114,21 @@ RSpec.describe "Gemini Structured Outputs Integration" do
       expect(selected).to be_available
     end
     
-    it "falls back to enhanced prompting for unsupported models" do
-      # Test with gemini-1.5-flash which is JSON-only, not full schema support
+    it "selects Gemini structured output strategy for Flash models (newly supported)" do
+      skip 'Requires GEMINI_API_KEY' unless ENV['GEMINI_API_KEY']
+      
+      # Test with gemini-1.5-flash which now supports structured outputs
       lm = DSPy::LM.new('gemini/gemini-1.5-flash', api_key: ENV['GEMINI_API_KEY'], structured_outputs: true)
+      selector = DSPy::LM::StrategySelector.new(lm.adapter, GeminiSentimentAnalysis)
+      
+      selected = selector.select
+      expect(selected.name).to eq('gemini_structured_output')
+      expect(selected).to be_available
+    end
+    
+    it "falls back to enhanced prompting for unsupported models" do
+      # Test with gemini-1.0-pro which doesn't support structured outputs
+      lm = DSPy::LM.new('gemini/gemini-1.0-pro', api_key: ENV['GEMINI_API_KEY'], structured_outputs: true)
       selector = DSPy::LM::StrategySelector.new(lm.adapter, GeminiSentimentAnalysis)
       
       selected = selector.select

--- a/spec/vcr_cassettes/model_matrix_google_gemini_2_0_flash_001.yml
+++ b/spec/vcr_cassettes/model_matrix_google_gemini_2_0_flash_001.yml
@@ -144,11 +144,11 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 13 Sep 2025 23:54:56 GMT
+      - Mon, 22 Sep 2025 15:48:54 GMT
       Server:
       - scaffolding on HTTPServer2
       Content-Length:
-      - '562'
+      - '563'
       X-Xss-Protection:
       - '0'
       X-Frame-Options:
@@ -156,7 +156,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Server-Timing:
-      - gfet4t7; dur=1402
+      - gfet4t7; dur=1478
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -168,19 +168,19 @@ http_interactions:
               "content": {
                 "parts": [
                   {
-                    "text": "```json\n{\n  \"action\": {\n    \"_type\": \"CreateTodoAction\",\n    \"title\": \"Model compatibility test\",\n    \"priority\": \"medium\",\n    \"tags\": [\n      \"testing\"\n    ]\n  },\n  \"affected_todos\": [\n    {\n      \"_type\": \"TodoItem\",\n      \"id\": \"todo-789\",\n      \"title\": \"Model compatibility test\",\n      \"description\": \"gemini-2.0-flash-001/enhanced_prompting\",\n      \"status\": \"pending\",\n      \"tags\": [\n        \"testing\"\n      ],\n      \"priority\": \"medium\"\n    }\n  ],\n  \"summary\": {\n    \"_type\": \"TodoSummary\",\n    \"total_todos\": 10,\n    \"upcoming_due\": 3\n  },\n  \"related_actions\": []\n}\n```"
+                    "text": "```json\n{\n  \"action\": {\n    \"_type\": \"CreateTodoAction\",\n    \"title\": \"model compatibility test todo\",\n    \"priority\": \"medium\",\n    \"tags\": [\n      \"testing\"\n    ]\n  },\n  \"affected_todos\": [\n    {\n      \"_type\": \"TodoItem\",\n      \"id\": \"todo-789\",\n      \"title\": \"model compatibility test todo\",\n      \"description\": \"gemini-2.0-flash-001/enhanced_prompting\",\n      \"status\": \"pending\",\n      \"tags\": [\n        \"testing\"\n      ],\n      \"priority\": \"medium\"\n    }\n  ],\n  \"summary\": {\n    \"_type\": \"TodoSummary\",\n    \"total_todos\": 10,\n    \"upcoming_due\": 3\n  },\n  \"related_actions\": []\n}\n```"
                   }
                 ],
                 "role": "model"
               },
               "finishReason": "STOP",
-              "avgLogprobs": -0.029157235784438049
+              "avgLogprobs": -0.029000183710685142
             }
           ],
           "usageMetadata": {
             "promptTokenCount": 2754,
-            "candidatesTokenCount": 206,
-            "totalTokenCount": 2960,
+            "candidatesTokenCount": 208,
+            "totalTokenCount": 2962,
             "promptTokensDetails": [
               {
                 "modality": "TEXT",
@@ -190,14 +190,14 @@ http_interactions:
             "candidatesTokensDetails": [
               {
                 "modality": "TEXT",
-                "tokenCount": 206
+                "tokenCount": 208
               }
             ]
           },
           "modelVersion": "gemini-2.0-flash-001",
-          "responseId": "TwTGaPPYJtaz1MkPkuP--Aw"
+          "responseId": "5W_RaM2VEKmkqtsPtYKQsQs"
         }
-  recorded_at: Sat, 13 Sep 2025 23:54:56 GMT
+  recorded_at: Mon, 22 Sep 2025 15:48:54 GMT
 - request:
     method: post
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-001:generateContent?key=<GEMINI_API_KEY>
@@ -309,18 +309,9 @@ http_interactions:
         [\n      \"backend\",\n      \"testing\",\n      \"priority\"\n    ]\n  },\n  \"user_profile\":
         {\n    \"user_id\": \"user-456\",\n    \"role\": \"admin\",\n    \"timezone\":
         \"UTC\"\n  }\n}\n```\n\nRespond with the corresponding output schema fields
-        wrapped in a ```json ``` block,\nstarting with the heading `## Output values`.\n\nIMPORTANT:
-        You must respond with valid JSON that matches this structure:\n```json\n{\n  \"action\":
-        \"example value\",\n  \"affected_todos\": [\n    {\n      \"_type\": \"example
-        string\",\n      \"id\": \"example string\",\n      \"title\": \"example string\",\n      \"description\":
-        \"example string\",\n      \"status\": \"example string\",\n      \"tags\":
-        [\n        \"example string\"\n      ],\n      \"priority\": \"example string\"\n    }\n  ],\n  \"summary\":
-        {\n    \"_type\": \"example string\",\n    \"total_todos\": 42,\n    \"upcoming_due\":
-        42\n  },\n  \"related_actions\": [\n    \"example value\"\n  ]\n}\n```\n\nRequired
-        fields: action, affected_todos, summary, related_actions\n\nEnsure your response:\n1.
-        Is valid JSON (properly quoted strings, no trailing commas)\n2. Includes all
-        required fields\n3. Uses the correct data types for each field\n4. Is wrapped
-        in ```json``` markdown code blocks\n"}]}]}'
+        wrapped in a ```json ``` block,\nstarting with the heading `## Output values`."}]}],"generation_config":{"response_mime_type":"application/json","response_json_schema":{"type":"object","properties":{"action":{"oneOf":[{"type":"object","properties":{"_type":{"type":"string"},"title":{"type":"string"},"priority":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["_type","title","priority","tags"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"updates":{"type":"string"},"reason":{"type":"string"}},"required":["_type","todo_id","updates","reason"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"reason":{"type":"string"}},"required":["_type","todo_id","reason"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"assignee":{"type":"string"},"notify":{"type":"boolean"}},"required":["_type","todo_id","assignee","notify"]}],"description":"Primary
+        action to execute - automatically discriminated by _type field"},"affected_todos":{"type":"array","items":{"type":"object","properties":{"_type":{"type":"string"},"id":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"status":{"type":"string","enum":["pending","in_progress","completed","failed"]},"tags":{"type":"array","items":{"type":"string"}},"priority":{"type":"string"}},"required":["_type","id","title","description","status","tags","priority"]}},"summary":{"type":"object","properties":{"_type":{"type":"string"},"total_todos":{"type":"integer"},"upcoming_due":{"type":"integer"}},"required":["_type","total_todos","upcoming_due"]},"related_actions":{"type":"array","items":{"oneOf":[{"type":"object","properties":{"_type":{"type":"string"},"title":{"type":"string"},"priority":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["_type","title","priority","tags"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"updates":{"type":"string"},"reason":{"type":"string"}},"required":["_type","todo_id","updates","reason"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"reason":{"type":"string"}},"required":["_type","todo_id","reason"]},{"type":"object","properties":{"_type":{"type":"string"},"todo_id":{"type":"string"},"assignee":{"type":"string"},"notify":{"type":"boolean"}},"required":["_type","todo_id","assignee","notify"]}],"description":"Union
+        of multiple types"}}},"required":["action","affected_todos","summary","related_actions"]}}}'
     headers:
       User-Agent:
       - Faraday v2.13.4
@@ -342,11 +333,11 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 13 Sep 2025 23:54:58 GMT
+      - Mon, 22 Sep 2025 15:48:56 GMT
       Server:
       - scaffolding on HTTPServer2
       Content-Length:
-      - '601'
+      - '507'
       X-Xss-Protection:
       - '0'
       X-Frame-Options:
@@ -354,7 +345,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Server-Timing:
-      - gfet4t7; dur=1668
+      - gfet4t7; dur=1355
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -366,34 +357,34 @@ http_interactions:
               "content": {
                 "parts": [
                   {
-                    "text": "## Output values\n```json\n{\n  \"action\": {\n    \"_type\": \"CreateTodoAction\",\n    \"title\": \"model compatibility test todo with medium priority (gemini-2.0-flash-001/gemini_structured_output)\",\n    \"priority\": \"medium\",\n    \"tags\": [\n      \"testing\"\n    ]\n  },\n  \"affected_todos\": [\n    {\n      \"_type\": \"TodoItem\",\n      \"id\": \"todo-987\",\n      \"title\": \"model compatibility test todo with medium priority (gemini-2.0-flash-001/gemini_structured_output)\",\n      \"description\": \"\",\n      \"status\": \"pending\",\n      \"tags\": [\n        \"testing\"\n      ],\n      \"priority\": \"medium\"\n    }\n  ],\n  \"summary\": {\n    \"_type\": \"TodoSummary\",\n    \"total_todos\": 10,\n    \"upcoming_due\": 2\n  },\n  \"related_actions\": []\n}\n```"
+                    "text": "{\n  \"action\": {\n    \"_type\": \"CreateTodoAction\",\n    \"title\": \"model compatibility test todo with medium priority (gemini-2.0-flash-001/gemini_structured_output)\",\n    \"priority\": \"medium\",\n    \"tags\": [\n      \"testing\"\n    ]\n  },\n  \"affected_todos\": [],\n  \"summary\": {\n    \"_type\": \"TodoSummary\",\n    \"total_todos\": 0,\n    \"upcoming_due\": 0\n  },\n  \"related_actions\": []\n}"
                   }
                 ],
                 "role": "model"
               },
               "finishReason": "STOP",
-              "avgLogprobs": -0.031409824950785578
+              "avgLogprobs": -0.027426294578138249
             }
           ],
           "usageMetadata": {
-            "promptTokenCount": 2755,
-            "candidatesTokenCount": 237,
-            "totalTokenCount": 2992,
+            "promptTokenCount": 2515,
+            "candidatesTokenCount": 129,
+            "totalTokenCount": 2644,
             "promptTokensDetails": [
               {
                 "modality": "TEXT",
-                "tokenCount": 2755
+                "tokenCount": 2515
               }
             ],
             "candidatesTokensDetails": [
               {
                 "modality": "TEXT",
-                "tokenCount": 237
+                "tokenCount": 129
               }
             ]
           },
           "modelVersion": "gemini-2.0-flash-001",
-          "responseId": "UQTGaImNDbKB1MkPwPe4qQ0"
+          "responseId": "52_RaNeJFN6BmtkPjvLTgA4"
         }
-  recorded_at: Sat, 13 Sep 2025 23:54:58 GMT
+  recorded_at: Mon, 22 Sep 2025 15:48:56 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
Enable native structured outputs for Gemini Flash models (1.5-flash, 2.0-flash variants) and add missing models to improve performance and reliability.

## Changes Made

### 🔧 Schema Converter Updates
- **Added support** for Gemini Flash models: `gemini-1.5-flash`, `gemini-1.5-flash-8b`, `gemini-1.5-flash-preview-0514`
- **Added support** for Gemini 2.0 models: `gemini-2.0-flash`, `gemini-2.0-flash-001`
- **Added support** for Gemini 2.5 Pro: `gemini-2.5-pro`
- **Renamed** `JSON_ONLY_MODELS` → `UNSUPPORTED_MODELS` for clarity
- **Simplified** unsupported models to only legacy Gemini 1.0 series

### 🧪 Test Updates
- Updated unit tests to verify Flash models now return `true` for structured output support
- Added comprehensive test coverage for all newly supported model variants
- Updated integration tests to verify Flash models use `gemini_structured_output` strategy
- Fixed fallback test to use genuinely unsupported model (`gemini-1.0-pro`)

### 🐛 VCR Cassette Fix
- Fixed test failure for `gemini-2.0-flash-001` caused by outdated VCR cassette
- Updated cassette now contains both enhanced prompting and structured output responses
- Resolved JSON parsing error: "unexpected character: '##' at line 1 column 1"

## Impact
- **Performance boost**: Flash models now use native structured outputs instead of enhanced prompting
- **Better reliability**: Native structured outputs are more consistent than prompt-based JSON extraction  
- **Cost efficiency**: More efficient token usage with structured outputs
- **Future-proof**: All current Gemini models 1.5+ now supported

## Test Results
✅ All 33 benchmark tests pass  
✅ All 5 Gemini structured output tests pass  
✅ All schema converter unit tests pass  
✅ JSON parsing works correctly for both strategies

## Notes
This change is based on updated Google documentation (Sept 2025) that confirms Flash models support structured outputs. Previously, these models were incorrectly categorized as JSON-only due to outdated information.

Related to PR #125 but focused specifically on the core schema converter changes without the bulk file cleanup.