### PR TITLE
Serialize OTLP exporting via concurrent-ruby executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ For LLMs and AI assistants working with DSPy.rb:
 
 ### Production Features
 - **[Storage System](docs/src/production/storage.md)** - Persistence and optimization result storage
-- **[Observability](docs/src/production/observability.md)** - Zero-config Langfuse integration and structured logging
+- **[Observability](docs/src/production/observability.md)** - Zero-config Langfuse integration with a dedicated export worker that never blocks your LLMs
 
 ### Advanced Usage
 - **[Complex Types](docs/src/advanced/complex-types.md)** - Sorbet type integration with automatic coercion for structs, enums, and arrays

--- a/docs/src/_articles/concurrent-llm-processing-performance-gains.md
+++ b/docs/src/_articles/concurrent-llm-processing-performance-gains.md
@@ -90,7 +90,7 @@ DSPy.rb builds on this solid foundation, providing async-aware features througho
 
 - [Concurrent predictions](https://vicentereig.github.io/dspy.rb/core-concepts/predictors/#concurrent-predictions) using `Async::Barrier`
 - Fiber-local context management for clean request isolation
-- Background telemetry processing with automatic retry handling
+- Background telemetry processing via a dedicated export worker with automatic retry handling
 - Non-blocking observability that doesn't slow down your application
 
 ## Implementing Concurrent Processing

--- a/spec/unit/observability/async_span_processor_spec.rb
+++ b/spec/unit/observability/async_span_processor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DSPy::Observability::AsyncSpanProcessor do
   let(:mock_exporter) { double('exporter') }
   let(:processor) { described_class.new(mock_exporter, export_interval: 0) } # Disable timer for tests
   
-  describe '#export_spans_with_retry_async' do
+  describe '#export_spans_with_retry' do
     it 'logs the number of spans being exported' do
       spans = [double('span1'), double('span2'), double('span3')]
       span_data = [double('span_data1'), double('span_data2'), double('span_data3')]
@@ -30,7 +30,7 @@ RSpec.describe DSPy::Observability::AsyncSpanProcessor do
         export_result: 'SUCCESS'
       )
       
-      processor.send(:export_spans_with_retry_async, spans)
+      processor.send(:export_spans_with_retry, spans)
     end
     
     it 'logs export failures with retry attempts' do
@@ -66,10 +66,9 @@ RSpec.describe DSPy::Observability::AsyncSpanProcessor do
         export_result: 'SUCCESS'
       )
       
-      # Mock async sleep
-      allow(Async::Task).to receive_message_chain(:current, :sleep)
+      allow(processor).to receive(:sleep)
       
-      processor.send(:export_spans_with_retry_async, spans)
+      processor.send(:export_spans_with_retry, spans)
     end
   end
   


### PR DESCRIPTION
## Summary
- replace the Async-based exporter scheduling with a Concurrent::SingleThreadExecutor
- serialize OTLP exports/flush/shutdown work onto that single worker to prevent frozen SSLContext crashes
- keep queueing non-blocking while simplifying the export pipeline and decoupling it from the Async reactor

## Why
Async let multiple fibers race into Net::HTTP simultaneously, triggering "can't modify frozen OpenSSL::SSL::SSLContext" during telemetry export. The single-thread executor preserves async-friendly queuing but ensures only one HTTP client mutates the SSL context at a time, resolving the race.

## Testing
- bundle exec rspec spec/integration/dspy/observability/async_span_processor_spec.rb
