### PR TITLE
Document new adapters for OpenAI, Anthropic, Gemini

### DIFF
--- a/lib/dspy/anthropic/README.md
+++ b/lib/dspy/anthropic/README.md
@@ -1,0 +1,36 @@
+# DSPy Anthropic adapter gem
+
+`dspy-anthropic` provides the Claude adapter for DSPy.rb so we can rely on Anthropic's API without bloating the core gem. Install it whenever you plan to call `anthropic/*` model ids from DSPy.
+
+## When you need it
+- You initialize `DSPy::LM` with an Anthropic provider (e.g. `anthropic/claude-3.5-sonnet`).
+- You want Claude's structured output helpers, tool use, or streaming responses.
+
+If your project only targets non-Claude providers you can omit this gem.
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'dspy'
+gem 'dspy-anthropic'
+```
+
+```sh
+bundle install
+```
+
+The adapter verifies that the official `anthropic` Ruby SDK `~> 1.12` is available and will raise if the version is missing or incompatible.
+
+## Configuration
+- Set `ENV['ANTHROPIC_API_KEY']`, or pass `api_key:` when constructing the LM.
+
+## Basic usage
+
+```ruby
+require 'dspy'
+# No need to explicitly require 'dspy/anthropic'
+
+lm = DSPy::LM.new('anthropic/claude-3.5-sonnet', api_key: ENV.fetch('ANTHROPIC_API_KEY'))
+
+```

--- a/lib/dspy/gemini/README.md
+++ b/lib/dspy/gemini/README.md
@@ -1,0 +1,37 @@
+# DSPy Gemini adapter gem
+
+`dspy-gemini` provides the Gemini adapter for DSPy.rb so we can rely on Google's API without bloating the core gem. Install it whenever you plan to call `gemini/*` model ids from DSPy.
+
+## When you need it
+- You call `DSPy::LM.new` with a provider of `gemini`.
+- You want structured outputs, multimodal prompts, or streaming responses backed by Gemini's Generative Language API.
+
+Projects that only target OpenAI, Anthropic, or other providers can skip this gem.
+
+## Installation
+Add it beside `dspy` and install dependencies:
+
+```ruby
+# Gemfile
+gem 'dspy'
+gem 'dspy-gemini'
+```
+
+```sh
+bundle install
+```
+
+The adapter enforces `gemini-ai ~> 4.3` at runtime (and raises if the dependency is missing or out of range).
+
+## Configuration
+- Set `ENV['GEMINI_API_KEY']`, or pass `api_key:` directly.
+
+## Basic usage
+
+```ruby
+require 'dspy'
+# No need to explicitly require 'dspy/gemini'
+
+lm = DSPy::LM.new('gemini/gemini-1.5-flash', api_key: ENV.fetch('GEMINI_API_KEY'))
+
+```

--- a/lib/dspy/openai/README.md
+++ b/lib/dspy/openai/README.md
@@ -1,0 +1,40 @@
+# DSPy OpenAI adapter gem
+
+`dspy-openai` packages the OpenAI-compatible adapters for DSPy.rb so we can keep the core `dspy` gem lean while still talking to GPT models (and any OpenAI-compatible endpoint). Install it whenever your project needs to invoke `openai/*`, `openrouter/*`, or `ollama/*` models through DSPy.
+
+## When you need it
+- You call `DSPy::LM.new` with a model id that starts with `openai/`, `openrouter/`, or `ollama/`.
+- You want to take advantage of structured outputs, streaming, or multimodal (vision) features exposed by OpenAI's API.
+
+If your project only uses non-OpenAI providers (e.g. Anthropic or Gemini) you can omit this gem entirely.
+
+## Installation
+Add the gem next to your `dspy` dependency and install Bundler dependencies:
+
+```ruby
+# Gemfile
+gem 'dspy'
+gem 'dspy-openai'
+```
+
+```sh
+bundle install
+```
+
+The gem depends on the official `openai` Ruby SDK (`~> 0.17`). The adapter checks this at load time and will raise if an incompatible version, or the older `ruby-openai` gem, is detected.
+
+## Basic usage
+
+```ruby
+require 'dspy'
+# No need to explicitly require 'dspy/openai'
+
+lm = DSPy::LM.new('openai/gpt-4o-mini', api_key: ENV.fetch('OPENAI_API_KEY'))
+
+```
+
+## Working with alternate providers
+- **OpenRouter**: instantiate with `DSPy::LM.new('openrouter/x-ai/grok-4-fast:free', api_key: ENV['OPENROUTER_API_KEY'])`. Any OpenAI-compatible model exposed by OpenRouter will work.
+- **Ollama**: use `DSPy::LM.new('ollama/llama3.2', api_key: nil)`.
+
+All three adapters share the same request handling, structured output support, and error reporting, so you can swap providers without changing higher-level DSPy code.


### PR DESCRIPTION
Following: https://github.com/vicentereig/dspy.rb/pull/178

Add introductory README.md files for the dspy-openai, dspy-anthropic, and dspy-gemini adapter gems. Each README explains when the adapter is needed, installation steps, configuration, and basic usage examples. These docs clarify how to use DSPy.rb with different LLM providers and help keep the core gem lean.

Part of: https://github.com/vicentereig/dspy.rb/issues/102