### PR TITLE
fix docs Next/Previous navigation

### DIFF
--- a/docs/src/_layouts/docs.liquid
+++ b/docs/src/_layouts/docs.liquid
@@ -476,22 +476,22 @@
         </article>
 
         <!-- Next/Previous navigation -->
-        {% if page.prev or page.next %}
+        {% if page.nav.prev or page.nav.next %}
         <nav class="mt-12 flex items-center justify-between border-t border-gray-200 pt-6">
-          {% if page.prev %}
+          {% if page.nav.prev %}
           <div class="flex-1">
-            <a href="{{ page.prev.url | relative_url }}" class="group flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
+            <a href="{{ page.nav.prev.url | relative_url }}" class="group flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
               <svg class="mr-3 h-5 w-5 flex-shrink-0 rotate-180 text-gray-400 group-hover:text-gray-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
               </svg>
-              {{ page.prev.title }}
+              {{ page.nav.prev.name }}
             </a>
           </div>
           {% endif %}
-          {% if page.next %}
+          {% if page.nav.next %}
           <div class="flex-1 text-right">
-            <a href="{{ page.next.url | relative_url }}" class="group flex items-center justify-end text-sm font-medium text-gray-500 hover:text-gray-700">
-              {{ page.next.title }}
+            <a href="{{ page.nav.next.url | relative_url }}" class="group flex items-center justify-end text-sm font-medium text-gray-500 hover:text-gray-700">
+              {{ page.nav.next.name }}
               <svg class="ml-3 h-5 w-5 flex-shrink-0 text-gray-400 group-hover:text-gray-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
               </svg>


### PR DESCRIPTION
Docs pages include the following bridgetown header

```yml
---
layout: docs
title: "DSPy Signatures: Type-Safe LLM Interfaces in Ruby"
name: Signatures
...
nav:
  prev:
    name: Core Concepts
    url: "/core-concepts/"
  next:
    name: Modules
    url: "/core-concepts/modules/"
```

However the Prev/Next navigation in `docs/src/_layouts/docs.liquid` misses the `nav` namespace in several footer references.

e.g.
```diff
- {% if page.prev or page.next %}
+ {% if page.nav.prev or page.nav.next %}
```

In addition it references `.title` instead of `.name`.

Fixes #208 