### PR TITLE
feat(anthropic): surface cache token fields in usage structs

### DIFF
--- a/lib/dspy/lm.rb
+++ b/lib/dspy/lm.rb
@@ -305,6 +305,12 @@ module DSPy
             span.set_attribute('gen_ai.usage.prompt_tokens', usage.input_tokens) if usage.input_tokens
             span.set_attribute('gen_ai.usage.completion_tokens', usage.output_tokens) if usage.output_tokens
             span.set_attribute('gen_ai.usage.total_tokens', usage.total_tokens) if usage.total_tokens
+            if usage.respond_to?(:cache_creation_input_tokens) && usage.cache_creation_input_tokens
+              span.set_attribute('gen_ai.usage.cache_creation_input_tokens', usage.cache_creation_input_tokens)
+            end
+            if usage.respond_to?(:cache_read_input_tokens) && usage.cache_read_input_tokens
+              span.set_attribute('gen_ai.usage.cache_read_input_tokens', usage.cache_read_input_tokens)
+            end
           end
         end
 
@@ -356,11 +362,16 @@ module DSPy
       
       # Handle Usage struct objects
       if response.usage.respond_to?(:input_tokens)
-        return {
+        result = {
           input_tokens: response.usage.input_tokens,
           output_tokens: response.usage.output_tokens,
           total_tokens: response.usage.total_tokens
-        }.compact
+        }
+        if response.usage.respond_to?(:cache_creation_input_tokens)
+          result[:cache_creation_input_tokens] = response.usage.cache_creation_input_tokens
+          result[:cache_read_input_tokens] = response.usage.cache_read_input_tokens
+        end
+        return result.compact
       end
       
       # Handle hash-based usage (for VCR compatibility)

--- a/lib/dspy/lm/response.rb
+++ b/lib/dspy/lm/response.rb
@@ -118,7 +118,7 @@ module DSPy
       extend T::Sig
       
       const :content, String
-      const :usage, T.nilable(T.any(Usage, OpenAIUsage)), default: nil
+      const :usage, T.nilable(T.any(Usage, OpenAIUsage, AnthropicUsage)), default: nil
       const :metadata, T.any(ResponseMetadata, OpenAIResponseMetadata, AnthropicResponseMetadata, GeminiResponseMetadata, T::Hash[Symbol, T.untyped])
       
       sig { returns(String) }

--- a/lib/dspy/lm/usage.rb
+++ b/lib/dspy/lm/usage.rb
@@ -45,11 +45,34 @@ module DSPy
       end
     end
     
+    # Anthropic-specific usage information with cache token fields
+    class AnthropicUsage < T::Struct
+      extend T::Sig
+
+      const :input_tokens, Integer
+      const :output_tokens, Integer
+      const :total_tokens, Integer
+      const :cache_creation_input_tokens, T.nilable(Integer), default: nil
+      const :cache_read_input_tokens, T.nilable(Integer), default: nil
+
+      sig { returns(Hash) }
+      def to_h
+        base = {
+          input_tokens: input_tokens,
+          output_tokens: output_tokens,
+          total_tokens: total_tokens
+        }
+        base[:cache_creation_input_tokens] = cache_creation_input_tokens if cache_creation_input_tokens
+        base[:cache_read_input_tokens] = cache_read_input_tokens if cache_read_input_tokens
+        base
+      end
+    end
+
     # Factory for creating appropriate usage objects
     module UsageFactory
       extend T::Sig
       
-      sig { params(provider: String, usage_data: T.untyped).returns(T.nilable(T.any(Usage, OpenAIUsage))) }
+      sig { params(provider: String, usage_data: T.untyped).returns(T.nilable(T.any(Usage, OpenAIUsage, AnthropicUsage))) }
       def self.create(provider, usage_data)
         return nil if usage_data.nil?
         
@@ -121,17 +144,19 @@ module DSPy
         nil
       end
       
-      sig { params(data: T::Hash[Symbol, T.untyped]).returns(T.nilable(Usage)) }
+      sig { params(data: T::Hash[Symbol, T.untyped]).returns(T.nilable(AnthropicUsage)) }
       def self.create_anthropic_usage(data)
         # Anthropic uses input_tokens/output_tokens
         input_tokens = data[:input_tokens] || 0
         output_tokens = data[:output_tokens] || 0
         total_tokens = data[:total_tokens] || (input_tokens + output_tokens)
-        
-        Usage.new(
+
+        AnthropicUsage.new(
           input_tokens: input_tokens,
           output_tokens: output_tokens,
-          total_tokens: total_tokens
+          total_tokens: total_tokens,
+          cache_creation_input_tokens: data[:cache_creation_input_tokens],
+          cache_read_input_tokens: data[:cache_read_input_tokens]
         )
       rescue StandardError => e
         DSPy.logger.debug("Failed to create Anthropic usage: #{e.message}")

--- a/spec/integration/dspy/lm/adapters/anthropic_adapter_spec.rb
+++ b/spec/integration/dspy/lm/adapters/anthropic_adapter_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe DSPy::Anthropic::LM::Adapters::AnthropicAdapter do
 
       expect(result).to be_a(DSPy::LM::Response)
       expect(result.content).to eq('Hello back!')
-      expect(result.usage).to be_a(DSPy::LM::Usage)
+      expect(result.usage).to be_a(DSPy::LM::AnthropicUsage)
       expect(result.usage.total_tokens).to eq(30)
       expect(result.metadata).to be_a(DSPy::LM::AnthropicResponseMetadata)
       expect(result.metadata.provider).to eq('anthropic')

--- a/spec/integration/token_usage_struct_spec.rb
+++ b/spec/integration/token_usage_struct_spec.rb
@@ -50,13 +50,50 @@ RSpec.describe 'Token usage with T::Struct' do
         output_tokens: 40,
         total_tokens: 120
       }
-      
+
       usage = DSPy::LM::UsageFactory.create('anthropic', usage_data)
-      
-      expect(usage).to be_a(DSPy::LM::Usage)
+
+      expect(usage).to be_a(DSPy::LM::AnthropicUsage)
       expect(usage.input_tokens).to eq(80)
       expect(usage.output_tokens).to eq(40)
       expect(usage.total_tokens).to eq(120)
+      expect(usage.cache_creation_input_tokens).to be_nil
+      expect(usage.cache_read_input_tokens).to be_nil
+    end
+
+    it 'creates Anthropic usage with cache fields' do
+      usage_data = {
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200
+      }
+
+      usage = DSPy::LM::UsageFactory.create('anthropic', usage_data)
+
+      expect(usage).to be_a(DSPy::LM::AnthropicUsage)
+      expect(usage.input_tokens).to eq(80)
+      expect(usage.output_tokens).to eq(40)
+      expect(usage.total_tokens).to eq(120)
+      expect(usage.cache_creation_input_tokens).to eq(500)
+      expect(usage.cache_read_input_tokens).to eq(200)
+    end
+
+    it 'creates Anthropic usage with zero cache fields' do
+      usage_data = {
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      }
+
+      usage = DSPy::LM::UsageFactory.create('anthropic', usage_data)
+
+      expect(usage).to be_a(DSPy::LM::AnthropicUsage)
+      expect(usage.cache_creation_input_tokens).to eq(0)
+      expect(usage.cache_read_input_tokens).to eq(0)
     end
   end
 
@@ -92,21 +129,70 @@ RSpec.describe 'Token usage with T::Struct' do
         total_tokens: 150,
         prompt_tokens_details: { cached_tokens: 0 }
       )
-      
+
       response = DSPy::LM::Response.new(
         content: '{"answer": "test"}',
         usage: usage,
         metadata: { provider: 'openai' }
       )
-      
-      # Token extraction is now internal to LM, test through actual LM usage
+
       lm = DSPy::LM.new('openai/gpt-4o-mini', api_key: 'test-key')
       tokens = lm.send(:extract_token_usage, response)
-      
+
       expect(tokens).to eq({
         input_tokens: 100,
         output_tokens: 50,
         total_tokens: 150
+      })
+    end
+
+    it 'extracts cache fields from AnthropicUsage struct' do
+      usage = DSPy::LM::AnthropicUsage.new(
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200
+      )
+
+      response = DSPy::LM::Response.new(
+        content: '{"answer": "test"}',
+        usage: usage,
+        metadata: { provider: 'anthropic' }
+      )
+
+      lm = DSPy::LM.new('anthropic/claude-sonnet-4-5-20250514', api_key: 'test-key')
+      tokens = lm.send(:extract_token_usage, response)
+
+      expect(tokens).to eq({
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200
+      })
+    end
+
+    it 'omits nil cache fields from AnthropicUsage extraction' do
+      usage = DSPy::LM::AnthropicUsage.new(
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120
+      )
+
+      response = DSPy::LM::Response.new(
+        content: '{"answer": "test"}',
+        usage: usage,
+        metadata: { provider: 'anthropic' }
+      )
+
+      lm = DSPy::LM.new('anthropic/claude-sonnet-4-5-20250514', api_key: 'test-key')
+      tokens = lm.send(:extract_token_usage, response)
+
+      expect(tokens).to eq({
+        input_tokens: 80,
+        output_tokens: 40,
+        total_tokens: 120
       })
     end
   end


### PR DESCRIPTION
## Summary
- Adds `AnthropicUsage` struct with `cache_creation_input_tokens` and `cache_read_input_tokens` fields
- Updates token extraction to include cache fields in usage hash and otel span attributes
- Allows applications to monitor Anthropic prompt caching effectiveness

## Test plan
- [ ] Tests cover nil, populated, and zero cache field values
- [ ] Adapter integration test expects `AnthropicUsage` type
- [ ] Extraction through Response objects works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)