### PR TITLE
feat(type_coercion): smart union handling for nilable structs

### DIFF
--- a/lib/dspy/mixins/type_coercion.rb
+++ b/lib/dspy/mixins/type_coercion.rb
@@ -179,6 +179,22 @@ module DSPy
         type.is_a?(T::Types::Union) && type.types.any? { |t| t == T::Utils.coerce(NilClass) }
       end
 
+      # Checks if a union type is a simple nilable struct (T.nilable(SomeStruct))
+      # Returns true only if the union has exactly 2 types: NilClass and a Struct
+      sig { params(union_type: T.untyped).returns(T::Boolean) }
+      def nilable_struct_union?(union_type)
+        return false unless union_type.is_a?(T::Types::Union)
+
+        types = union_type.types
+        return false unless types.size == 2
+
+        # One type must be NilClass, the other must be a struct
+        has_nil = types.any? { |t| t == T::Utils.coerce(NilClass) }
+        struct_type = types.find { |t| t != T::Utils.coerce(NilClass) && struct_type?(t) }
+
+        has_nil && !struct_type.nil?
+      end
+
       # Checks if a type is a scalar (primitives that don't need special serialization)
       sig { params(type_object: T.untyped).returns(T::Boolean) }
       def scalar_type?(type_object)
@@ -391,7 +407,16 @@ module DSPy
 
         return value unless value.is_a?(Hash)
 
-        # Check for _type discriminator field
+        # Handle nilable struct unions (T.nilable(SomeStruct)) without _type discriminator
+        # LLMs don't provide _type for simple nilable structs, so we can directly coerce
+        if nilable_struct_union?(union_type)
+          struct_type = union_type.types.find { |t|
+            t != T::Utils.coerce(NilClass) && struct_type?(t)
+          }
+          return coerce_struct_value(value, struct_type) if struct_type
+        end
+
+        # Check for _type discriminator field (required for true multi-type unions)
         type_name = value[:_type] || value["_type"]
         return value unless type_name
 

--- a/spec/unit/dspy/mixins/type_coercion_spec.rb
+++ b/spec/unit/dspy/mixins/type_coercion_spec.rb
@@ -301,6 +301,91 @@ RSpec.describe DSPy::Mixins::TypeCoercion do
       end
     end
 
+    context 'with nilable struct unions without _type discriminator (smart union handling)' do
+      it 'coerces Hash to struct without _type discriminator' do
+        nilable_type = T.nilable(TestStructs::AnswerAction)
+        hash_value = {
+          "content" => "No discriminator needed",
+          "confidence" => 0.95
+        }
+
+        result = instance.test_coerce(hash_value, nilable_type)
+
+        expect(result).to be_a(TestStructs::AnswerAction)
+        expect(result.content).to eq("No discriminator needed")
+        expect(result.confidence).to eq(0.95)
+      end
+
+      it 'strips _type field from nilable struct union if present' do
+        nilable_type = T.nilable(TestStructs::SearchAction)
+        hash_value = {
+          "_type" => "SearchAction",
+          "query" => "test query",
+          "max_results" => 15
+        }
+
+        result = instance.test_coerce(hash_value, nilable_type)
+
+        expect(result).to be_a(TestStructs::SearchAction)
+        expect(result.query).to eq("test query")
+        expect(result.max_results).to eq(15)
+        # Verify _type was stripped
+        expect(result).not_to respond_to(:_type)
+      end
+
+      it 'returns nil when value is nil for nilable struct' do
+        nilable_type = T.nilable(TestStructs::AnswerAction)
+
+        result = instance.test_coerce(nil, nilable_type)
+
+        expect(result).to be_nil
+      end
+
+      it 'handles nested structs in nilable struct unions without _type' do
+        nilable_type = T.nilable(TestStructs::Person)
+        hash_value = {
+          "name" => "John Smith",
+          "address" => {
+            "street" => "456 Pine St",
+            "city" => "Newtown"
+          }
+        }
+
+        result = instance.test_coerce(hash_value, nilable_type)
+
+        expect(result).to be_a(TestStructs::Person)
+        expect(result.name).to eq("John Smith")
+        expect(result.address).to be_a(TestStructs::Address)
+        expect(result.address.street).to eq("456 Pine St")
+        expect(result.address.city).to eq("Newtown")
+      end
+
+      it 'parses JSON string without _type for nilable struct' do
+        nilable_type = T.nilable(TestStructs::SearchAction)
+        json_string = '{"query": "no type field", "max_results": 25}'
+
+        result = instance.test_coerce(json_string, nilable_type)
+
+        expect(result).to be_a(TestStructs::SearchAction)
+        expect(result.query).to eq("no type field")
+        expect(result.max_results).to eq(25)
+      end
+
+      it 'uses default values for optional struct fields' do
+        nilable_type = T.nilable(TestStructs::SearchAction)
+        hash_value = {
+          "query" => "minimal query"
+          # max_results omitted, should use default of 5
+        }
+
+        result = instance.test_coerce(hash_value, nilable_type)
+
+        expect(result).to be_a(TestStructs::SearchAction)
+        expect(result.query).to eq("minimal query")
+        expect(result.max_results).to eq(5)  # Default value
+      end
+    end
+
     context 'with existing type handling' do
       it 'still handles simple types correctly' do
         # Use T::Utils.coerce to get proper Sorbet type objects


### PR DESCRIPTION
## Summary
- Detects T.nilable(SomeStruct) unions (exactly NilClass + one struct) and coerces directly without requiring _type discriminator
- LLMs do not provide _type discriminator for simple nilable structs, so we detect this pattern and skip the _type check

Fixes #226

## Test plan
- [ ] Nilable struct unions coerce without _type field
- [ ] _type field is stripped when present on nilable struct unions
- [ ] Nested structs work within nilable wrappers
- [ ] JSON string values are parsed correctly for nilable structs
- [ ] Default values for optional struct fields are preserved