### PR TITLE
fix(type-coercion): fall back on malformed hash strings

### DIFF
--- a/lib/dspy/mixins/type_coercion.rb
+++ b/lib/dspy/mixins/type_coercion.rb
@@ -311,10 +311,7 @@ module DSPy
       def coerce_hash_value(value, prop_type)
         return value unless prop_type.is_a?(T::Types::TypedHash)
 
-        if value.is_a?(String)
-          parsed = YAML.safe_load(value, permitted_classes: [Symbol, Date, Time])
-          value = parsed if parsed.is_a?(Hash)
-        end
+        value = try_parse_string_to_hash(value)
         return value unless value.is_a?(Hash)
 
         key_type = prop_type.keys
@@ -331,6 +328,23 @@ module DSPy
         
         # Coerce values to their expected types
         result.transform_values { |v| coerce_value_to_type(v, value_type) }
+      end
+
+      # Attempts to parse a string into a Hash.
+      # Returns the parsed Hash on success, or the original value otherwise.
+      sig { params(value: T.untyped).returns(T.untyped) }
+      def try_parse_string_to_hash(value)
+        return value unless value.is_a?(String)
+
+        parsed = begin
+          JSON.parse(value)
+        rescue JSON::ParserError
+          YAML.safe_load(value, permitted_classes: [Symbol, Date, Time])
+        end
+
+        parsed.is_a?(Hash) ? parsed : value
+      rescue Psych::SyntaxError
+        value
       end
 
       # Attempts to parse a JSON string into a Hash.

--- a/spec/unit/dspy/mixins/type_coercion_spec.rb
+++ b/spec/unit/dspy/mixins/type_coercion_spec.rb
@@ -644,6 +644,12 @@ RSpec.describe DSPy::Mixins::TypeCoercion do
         expect(result).to eq("not a hash")
       end
 
+      it 'returns malformed hash-like strings unchanged' do
+        result = instance.test_coerce("{query: [}", hash_type)
+
+        expect(result).to eq("{query: [}")
+      end
+
       it 'parses a JSON string into a Hash when expected type is T::Hash' do
         json_string = '{"query": "AI safety research"}'
         result = instance.test_coerce(json_string, hash_type)


### PR DESCRIPTION
## Summary
- rescue malformed inline hash strings during T::Hash coercion
- reuse a helper so hash-string parsing fails soft instead of raising
- add a regression spec for malformed hash-like input

## Context
Follow-up to #237. That PR added support for stringified hash fields in coerce_hash_value, but malformed inline-hash strings could still raise Psych::SyntaxError during enhanced-prompting / TOON flows.

## Testing
- rbenv exec bundle exec rspec spec/unit/dspy/mixins/type_coercion_spec.rb