### PR TITLE
fix(toon): treat empty key-value as nil for nilable scalar fields

### DIFF
--- a/spec/sorbet/toon/signature_reconstruction_spec.rb
+++ b/spec/sorbet/toon/signature_reconstruction_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe 'Sorbet::Toon.decode with signatures' do
         const :sources, T::Array[Source]
       end
     end
+
+    class PersonSignature < DSPy::Signature
+      input do
+        const :query, String
+      end
+
+      output do
+        const :name, String
+        const :nickname, T.nilable(String)
+      end
+    end
+
+    class ProfileSignature < DSPy::Signature
+      input do
+        const :query, String
+      end
+
+      output do
+        const :name, String
+        const :nickname, T.nilable(String)
+        const :metadata, T.nilable(T::Hash[String, String])
+        const :source, T.nilable(Source)
+      end
+    end
   end
 
   let(:signature) { SorbetToonSignatureSpec::ReportSignature }
@@ -49,6 +73,56 @@ RSpec.describe 'Sorbet::Toon.decode with signatures' do
     expect(result.sources.length).to eq(2)
     expect(result.sources.first).to be_a(SorbetToonSignatureSpec::Source)
     expect(result.sources.last.notes).to eq('top pick')
+  end
+
+  it 'treats empty key-value as nil for nilable string fields' do
+    payload = <<~TOON
+      name: Ada
+      nickname:
+    TOON
+
+    result = Sorbet::Toon.decode(
+      payload,
+      signature: SorbetToonSignatureSpec::PersonSignature,
+      role: :output
+    )
+
+    expect(result.name).to eq('Ada')
+    expect(result.nickname).to be_nil
+  end
+
+  it 'preserves empty key-value as empty hash for nilable hash fields' do
+    payload = <<~TOON
+      name: Ada
+      nickname:
+      metadata:
+    TOON
+
+    result = Sorbet::Toon.decode(
+      payload,
+      signature: SorbetToonSignatureSpec::ProfileSignature,
+      role: :output
+    )
+
+    expect(result.name).to eq('Ada')
+    expect(result.nickname).to be_nil
+    expect(result.metadata).to eq({})
+  end
+
+  it 'treats empty key-value as nil for nilable struct with required fields' do
+    payload = <<~TOON
+      name: Ada
+      source:
+    TOON
+
+    result = Sorbet::Toon.decode(
+      payload,
+      signature: SorbetToonSignatureSpec::ProfileSignature,
+      role: :output
+    )
+
+    expect(result.name).to eq('Ada')
+    expect(result.source).to be_nil
   end
 
   it 'rehydrates using explicit struct_class without signature' do


### PR DESCRIPTION
## Summary

Failing tests that illustrate #241 — when the TOON codec decodes `key:` with no value, it returns `{}` per [TOON spec §8](https://github.com/toon-format/spec/blob/main/SPEC.md#8-objects). This causes `TypeError: Cannot coerce Hash to String` when the field is a nilable scalar like `T.nilable(String)`.

## Tests added

- **`treats empty key-value as nil for nilable string fields`** — `nickname:` with no value should be `nil`, not `{}`
- **`preserves empty key-value as empty hash for nilable hash fields`** — `metadata:` with no value should remain `{}` since it's a valid empty hash
- **`treats empty key-value as nil for nilable struct with required fields`** — `source:` with no value should be `nil` when the struct has required fields

Ref #241