### PR TITLE
Fix stringified JSON array coercion.

### DIFF
--- a/lib/dspy/mixins/type_coercion.rb
+++ b/lib/dspy/mixins/type_coercion.rb
@@ -299,8 +299,10 @@ module DSPy
       # Coerces an array value, converting each element as needed
       sig { params(value: T.untyped, prop_type: T.untyped).returns(T.untyped) }
       def coerce_array_value(value, prop_type)
-        return value unless value.is_a?(Array)
         return value unless prop_type.is_a?(T::Types::TypedArray)
+
+        value = try_parse_string_to_array(value)
+        return value unless value.is_a?(Array)
 
         element_type = prop_type.type
         value.map { |element| coerce_value_to_type(element, element_type) }
@@ -344,6 +346,18 @@ module DSPy
 
         parsed.is_a?(Hash) ? parsed : value
       rescue Psych::SyntaxError
+        value
+      end
+
+      # Attempts to parse a JSON string into an Array.
+      # Returns the parsed Array on success, or the original value otherwise.
+      sig { params(value: T.untyped).returns(T.untyped) }
+      def try_parse_string_to_array(value)
+        return value unless value.is_a?(String)
+
+        parsed = JSON.parse(value)
+        parsed.is_a?(Array) ? parsed : value
+      rescue JSON::ParserError
         value
       end
 

--- a/spec/unit/dspy/mixins/type_coercion_spec.rb
+++ b/spec/unit/dspy/mixins/type_coercion_spec.rb
@@ -407,6 +407,20 @@ RSpec.describe DSPy::Mixins::TypeCoercion do
         expect(result).to eq([1, 2, 3])
       end
 
+      it 'parses JSON array strings for typed arrays' do
+        array_type = T::Array[Integer]
+        result = instance.test_coerce('[1, 2, 3]', array_type)
+
+        expect(result).to eq([1, 2, 3])
+      end
+
+      it 'parses JSON array strings for typed enum arrays' do
+        array_type = T::Array[TestStructs::Priority]
+        result = instance.test_coerce('["low", "high"]', array_type)
+
+        expect(result).to eq([TestStructs::Priority::Low, TestStructs::Priority::High])
+      end
+
       it 'rejects integers when String is required (strict type safety)' do
         string_type = T::Utils.coerce(String)
         expect { instance.test_coerce(123, string_type) }.to raise_error(TypeError, /Cannot coerce Integer to String/)


### PR DESCRIPTION
## Summary

`DSPy::Mixins::TypeCoercion` now treats JSON array **strings** like real arrays when the target type is a `T::Array[...]`, so values such as `'[1, 2, 3]'` are parsed and element coercion runs as usual. This aligns typed array handling with how stringified JSON is already handled elsewhere (e.g. hashes) and fixes inconsistent behavior for tool arguments and other inputs that arrive as strings.

## Changes

- **`coerce_array_value`**: For typed arrays, call `try_parse_string_to_array` before requiring an `Array`; non-array strings and parse failures stay unchanged.
- **`try_parse_string_to_array`**: If the value is a `String`, `JSON.parse` it; only replace with the result when it is an `Array`; rescue `JSON::ParserError` and return the original string.

## Tests

- Unit examples for `T::Array[Integer]` and `T::Array[<enum>]` from JSON array strings (`spec/unit/dspy/mixins/type_coercion_spec.rb`).

Fixes #249 