### PR TITLE
Document Tuning Engines through the RubyLLM adapter

### DIFF
--- a/lib/dspy/ruby_llm/README.md
+++ b/lib/dspy/ruby_llm/README.md
@@ -47,6 +47,25 @@ lm = DSPy::LM.new("ruby_llm/llama3.2", provider: 'ollama')
 
 The adapter detects the provider from RubyLLM's model registry. For models not in the registry, use the `provider:` option.
 
+### Governed OpenAI-compatible endpoints
+
+Because the adapter uses your RubyLLM configuration, Ruby and Rails apps can route DSPy calls through an OpenAI-compatible control plane such as [Tuning Engines](https://www.tuningengines.com/) without changing higher-level DSPy modules:
+
+```ruby
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV.fetch('TUNING_ENGINES_API_KEY')
+  config.openai_api_base = 'https://api.tuningengines.com/v1'
+end
+
+lm = DSPy::LM.new(
+  "ruby_llm/#{ENV.fetch('TUNING_ENGINES_MODEL', 'gpt-4o-mini')}",
+  provider: 'openai',
+  assume_model_exists: true
+)
+```
+
+This keeps DSPy responsible for program structure and optimization while Tuning Engines centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
 ### Provider Override
 
 For custom deployments or models not in the registry, explicitly specify the provider:


### PR DESCRIPTION
## Summary

- Adds a small documentation example for using Tuning Engines through the existing OpenAI-compatible configuration surface.
- Keeps the project API unchanged: no dependencies, no adapter changes, and no runtime behavior changes.
- Shows how Ruby/Rails teams can keep this project in charge of application, agent, tool, or workflow logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI application code.

This project already supports OpenAI-compatible configuration. The docs change makes that existing capability discoverable for Ruby/Rails teams without asking the project to add a new provider, dependency, SDK, or runtime integration.

## Testing

- `git diff --check`
