### PR TITLE
fix: ReAct drops the user signature description from the LM prompt

### DIFF
--- a/lib/dspy/re_act.rb
+++ b/lib/dspy/re_act.rb
@@ -302,6 +302,16 @@ module DSPy
       action_enum_class = @action_enum_class
       input_context_type = signature_class.input_struct_class || String
 
+      # Carry the user signature's instructions into the loop prompt, then append the
+      # loop mechanics — mirroring Python DSPy's ReAct, which prepends
+      # signature.instructions to the react predictor's instructions. Without this the
+      # user's task description never reaches the LM: it is only set on the enhanced
+      # signature used for typing, which issues no LM calls.
+      thought_description = [
+        signature_class.description,
+        "Generate a thought about what to do next to process the given inputs."
+      ].compact.reject(&:empty?).join("\n\n")
+
       # Get the output field type for the final_answer field
       output_field_name = signature_class.output_struct_class.props.keys.first
       output_field_type = signature_class.output_struct_class.props[output_field_name][:type_object]
@@ -309,7 +319,7 @@ module DSPy
       # Create new class that inherits from DSPy::Signature
       Class.new(DSPy::Signature) do
         # Set description
-        description "Generate a thought about what to do next to process the given inputs."
+        description thought_description
 
         # Define input fields
         input do

--- a/spec/unit/dspy/re_act_instructions_spec.rb
+++ b/spec/unit/dspy/re_act_instructions_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'dspy/re_act'
+
+class DescribedAgentSignature < DSPy::Signature
+  description "You are a pirate assistant. Always answer in pirate speak."
+
+  input do
+    const :question, String
+  end
+
+  output do
+    const :answer, String
+  end
+end
+
+class UndescribedAgentSignature < DSPy::Signature
+  input do
+    const :question, String
+  end
+
+  output do
+    const :answer, String
+  end
+end
+
+RSpec.describe 'ReAct thought generator instructions', type: :unit do
+  let(:thought_instruction) do
+    ->(agent) { agent.instance_variable_get(:@thought_generator).prompt.instruction }
+  end
+
+  it 'carries the user signature description into the loop prompt' do
+    agent = DSPy::ReAct.new(DescribedAgentSignature, tools: [])
+
+    expect(thought_instruction.call(agent))
+      .to start_with("You are a pirate assistant. Always answer in pirate speak.")
+  end
+
+  it 'appends the loop mechanics after the user instructions' do
+    agent = DSPy::ReAct.new(DescribedAgentSignature, tools: [])
+
+    expect(thought_instruction.call(agent))
+      .to end_with("Generate a thought about what to do next to process the given inputs.")
+  end
+
+  it 'falls back to the loop mechanics alone when the signature has no description' do
+    agent = DSPy::ReAct.new(UndescribedAgentSignature, tools: [])
+
+    expect(thought_instruction.call(agent))
+      .to eq("Generate a thought about what to do next to process the given inputs.")
+  end
+
+  it 'still honors with_instruction overrides' do
+    agent = DSPy::ReAct.new(DescribedAgentSignature, tools: []).with_instruction("Custom override.")
+
+    expect(thought_instruction.call(agent)).to eq("Custom override.")
+  end
+end


### PR DESCRIPTION
## Problem

`DSPy::ReAct` never delivers the user signature's `description` to the LM. `create_thought_signature` builds the internal thought signature with a hardcoded generic description:

```ruby
description "Generate a thought about what to do next to process the given inputs."
```

while the user's description is only set on the *enhanced signature* used for typing — which never issues an LM call. So everything a user writes in their signature description (persona, behavioral rules, constraints) is silently dropped during the agent loop.

### Minimal repro

```ruby
class SimpleOne < DSPy::Signature
  description "MARKER_XYZ: No matter what is asked, the reply must be exactly PINEAPPLE."
  input  { const :question, String }
  output { const :reply, String }
end

agent = DSPy::ReAct.new(SimpleOne, tools: [])
agent.prompt.instruction
# => "Generate a thought about what to do next to process the given inputs."
```

Spying on the messages passed to `DSPy::LM#chat_with_strategy` confirms `MARKER_XYZ` never appears in any byte sent to the provider; asked "What is the capital of France?", the agent answers "The capital of France is Paris." — the description is ignored. A plain `DSPy::Predict.new(SimpleOne)` control answers "PINEAPPLE", since Predict uses the description natively. Reproduced on 0.34.3 and 1.0.0 with `gemini-2.5-flash`.

## Fix

Prepend the user signature's description to the thought signature's description, keeping the loop-mechanics line after it. This mirrors Python DSPy's ReAct, which prepends the user instructions to the react predictor's instructions ([react.py](https://github.com/stanfordnlp/dspy/blob/main/dspy/predict/react.py)):

```python
instr = [f"{signature.instructions}\n"] if signature.instructions else []
```

Signatures without a description keep today's prompt byte-for-byte, and `with_instruction` overrides are unaffected (covered by specs).

## Testing

- New unit spec `spec/unit/dspy/re_act_instructions_spec.rb` (description carried, mechanics appended, nil-description fallback, `with_instruction` override).
- Full unit suite: 1017 examples, 0 failures, 8 pending (pendings pre-existing).
- `spec/integration/dspy/re_act_spec.rb`: same results as `main` in my environment (failures there are pre-existing/key-dependent, count unchanged by this patch).

## Real-world impact

Found while evaluating a production support agent: with the generic instruction, the agent invented policies instead of escalating and escalated off-topic questions, because none of the rules in its signature description ever reached the model. Applying the description via `with_instruction` (this patch's behavior) took its eval set from failing to passing.