### PR TITLE
Run complete integration suite in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - '*'
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -36,6 +40,20 @@ jobs:
           code_act: '0'
           schema: '1'
           gepa: '0'
+          o11y: '1'
+          o11y_langfuse: '1'
+        - name: DSPy Integration
+          gem: dspy
+          command: bundle exec rspec --format documentation --pattern 'spec/**/*_spec.rb'
+            --exclude-pattern 'spec/unit/**/*_spec.rb'
+          install_arrow: 'true'
+          install_openblas: 'true'
+          datasets: '1'
+          miprov2: '1'
+          evals: '1'
+          code_act: '1'
+          schema: '1'
+          gepa: '1'
           o11y: '1'
           o11y_langfuse: '1'
         - name: DSPy DeepSearch
@@ -224,5 +242,5 @@ jobs:
         GEMINI_API_KEY: test-gemini-key-for-vcr
         OPENROUTER_API_KEY: test-openrouter-key-for-vcr
         EXA_API_KEY: test-exa-key-for-vcr
-        LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-        LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+        LANGFUSE_PUBLIC_KEY: test-langfuse-public-key-for-vcr
+        LANGFUSE_SECRET_KEY: test-langfuse-secret-key-for-vcr

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ examples/*_report.html
 .idea
 .byebug_history
 .env
+.env.*
+!.env.sample
 *.gem
 notes/
 .rspec_status

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,8 @@ VCR.configure do |config|
   config.filter_sensitive_data('<OPENROUTER_API_KEY>') { ENV['OPENROUTER_API_KEY'] }
   config.filter_sensitive_data('<EXA_API_KEY>') { ENV['EXA_API_KEY'] }
   config.filter_sensitive_data('<NEW_RELIC_LICENSE_KEY>') { ENV['NEW_RELIC_LICENSE_KEY'] }
+  config.filter_sensitive_data('<LANGFUSE_PUBLIC_KEY>') { ENV['LANGFUSE_PUBLIC_KEY'] }
+  config.filter_sensitive_data('<LANGFUSE_SECRET_KEY>') { ENV['LANGFUSE_SECRET_KEY'] }
 
   # Filter out sensitive headers and response data
   # Organization IDs in OpenAI responses
@@ -78,6 +80,10 @@ VCR.configure do |config|
 
   # Filter out cookies - use a more comprehensive approach
   config.before_record do |interaction|
+    %w[Authorization Proxy-Authorization X-Api-Key Cookie].each do |header|
+      interaction.request.headers[header] = ['<REDACTED>'] if interaction.request.headers[header]
+    end
+
     # Redact Set-Cookie headers
     if interaction.response.headers['Set-Cookie']
       interaction.response.headers['Set-Cookie'] = interaction.response.headers['Set-Cookie'].map do |cookie|


### PR DESCRIPTION
## Summary

- run every non-unit spec in a dedicated DSPy Integration matrix job
- enable all optional DSPy components and their native dependencies for that job
- remove repository Langfuse secrets from pull-request test jobs
- redact Langfuse credentials and sensitive request headers in future VCR recordings
- ignore local `.env.*` files while preserving `.env.sample`
- declare read-only `GITHUB_TOKEN` permissions

## Why

Issue #258 exposed a structural CI gap: the workflow enumerated a few integration specs, so new or existing non-unit specs could silently remain outside GitHub Actions.

This proposal uses a catchall instead:

```sh
bundle exec rspec --pattern 'spec/**/*_spec.rb' --exclude-pattern 'spec/unit/**/*_spec.rb'
```

Core and optional-gem jobs retain focused unit coverage. The catchall owns every non-unit spec by convention, including the five Anthropic surfaces from #258. A per-file manifest and coverage parser would duplicate RSpec's inventory while providing weaker guarantees.

The stable Anthropic cassette migration itself remains coupled to PR #257's endpoint change and should land there; current `main` still intentionally uses the beta request shape.

## Verification

- Exact new matrix command with all feature flags: **1,381 examples, 0 failures, 27 expected pending**
- Workflow YAML parses successfully
- `spec/spec_helper.rb` syntax check passes
- 206 spec files partition structurally into 108 unit and 98 non-unit files, with zero unowned paths
- `git diff --check` passes

RuboCop is not available in the current bundle.

Related to #258.